### PR TITLE
Have babel ignore test files when transpiling code.

### DIFF
--- a/buildPackages.js
+++ b/buildPackages.js
@@ -14,7 +14,7 @@ packages.forEach(function(pack) {
     if (!fs.existsSync(path.join(pack, 'package.json'))) return;
 
 // install folder
-    spawn.sync('babel', [path.resolve(pack+'/src'), '--out-dir', './lib', '--ignore', 'test.js'], {env: process.env, cwd: pack, stdio: 'inherit'});
+    spawn.sync('babel', [path.resolve(pack+'/src'), '--out-dir', './lib', '--ignore', '*.test.js,*.spec.js'], {env: process.env, cwd: pack, stdio: 'inherit'});
     spawn.sync('npm', ['run', 'build-css'], {env: process.env, cwd: pack, stdio: 'inherit'});
     spawn.sync('npm', ['run', 'clean:mainJS'], {env: process.env, cwd: pack, stdio: 'inherit'});
 });

--- a/buildPackages.js
+++ b/buildPackages.js
@@ -14,7 +14,7 @@ packages.forEach(function(pack) {
     if (!fs.existsSync(path.join(pack, 'package.json'))) return;
 
 // install folder
-    spawn.sync('babel', [path.resolve(pack+'/src'), '--out-dir', './lib'], {env: process.env, cwd: pack, stdio: 'inherit'});
+    spawn.sync('babel', [path.resolve(pack+'/src'), '--out-dir', './lib', '--ignore', 'test.js'], {env: process.env, cwd: pack, stdio: 'inherit'});
     spawn.sync('npm', ['run', 'build-css'], {env: process.env, cwd: pack, stdio: 'inherit'});
     spawn.sync('npm', ['run', 'clean:mainJS'], {env: process.env, cwd: pack, stdio: 'inherit'});
 });


### PR DESCRIPTION
This commit has babel skip any files named `test.js` during the building/transpilling of code in `src`. 