### PR TITLE
Ignore code coverage report.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ styleguide
 .npmrc
 jsconfig.json
 lerna-debug.log
+coverage


### PR DESCRIPTION
Add the coverage folder/directory to the git ignore list so it doesn't get added to the repo accidentally.