### PR TITLE
Fix classNames not a function error

### DIFF
--- a/packages/react-atlas-core/src/header/Header.js
+++ b/packages/react-atlas-core/src/header/Header.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { classNames } from '../utils/utils';
+import { classNames } from '../utils';
 import themeable from 'react-themeable';
 
 const Header = ({className, fixed, children, ...props}) => {

--- a/packages/react-atlas-core/src/input/Input.js
+++ b/packages/react-atlas-core/src/input/Input.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import { classNames } from '../utils/utils';
+import { classNames } from '../utils';
 import themeable from 'react-themeable';
 
 /**
@@ -74,7 +74,7 @@ Input.styleguide = {
   />
 
   <Button>Submit</Button>
-</section>  
+</section>
 `
 };
 

--- a/packages/react-atlas-core/src/slider/Slider.js
+++ b/packages/react-atlas-core/src/slider/Slider.js
@@ -4,7 +4,7 @@ import themeable from 'react-themeable';
 import classNames from 'classnames/bind';
 import events from '../utils/events';
 import prefixer from '../utils/prefixer';
-import utils from '../utils/utils';
+import utils from '../utils';
 import ProgressBar from '../progress_bar';
 import Input from '../input';
 

--- a/packages/react-atlas-core/src/utils/classNames.js
+++ b/packages/react-atlas-core/src/utils/classNames.js
@@ -1,0 +1,15 @@
+export default function classNames(...options) {
+  let cn = [];
+  options.forEach(opt => {
+  if(opt) {
+    if(typeof opt === 'string') {
+      cn.push(opt);
+       }
+       if(typeof opt === 'object') {
+         let keys = Object.keys(opt).filter(key => !!opt[key]);
+         cn.push(...keys);
+       }
+     }
+   });
+   return cn;
+ }; 

--- a/packages/react-atlas-core/src/utils/index.js
+++ b/packages/react-atlas-core/src/utils/index.js
@@ -2,5 +2,6 @@ import events from './events';
 import prefixer from './prefixer';
 import time from './time';
 import utils from './utils';
+import classNames from './classNames';
 
-export {events, prefixer, time, utils};
+export {events, prefixer, time, utils, classNames};


### PR DESCRIPTION
This fixes bug #85. The form, hint, input, radio, radiogroup, overlay, header, snackbar and media components are fixed by this commit. Progressbar, slider and drawer now show new errors besides for the original classNames type error.