### PR TITLE
Switch all components to local version of classNames()

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "license": "MIT",
   "dependencies": {
     "blacklist": "^1.1.2",
-    "classnames": "^2.2.5",
     "react": "^15.0.2",
     "react-dom": "^15.0.2",
     "react-addons-css-transition-group": "^15.0.2",

--- a/packages/react-atlas-core/package.json
+++ b/packages/react-atlas-core/package.json
@@ -28,7 +28,6 @@
   "license": "MIT",
   "dependencies": {
     "blacklist": "^1.1.2",
-    "classnames": "^2.2.5",
     "react": "^15.0.2",
     "react-dom": "^15.0.2",
     "normalize.css": "^4.1.1",

--- a/packages/react-atlas-core/src/card/Card.js
+++ b/packages/react-atlas-core/src/card/Card.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import classNames from 'classnames/bind';
+import { classNames } from '../utils';
 import themeable from 'react-themeable';
 
 /**

--- a/packages/react-atlas-core/src/checkbox/Checkbox.js
+++ b/packages/react-atlas-core/src/checkbox/Checkbox.js
@@ -7,7 +7,7 @@ import themeable from 'react-themeable';
  */
 const Checkbox = ({title, label, disabled, inline, className, ...props}) => {
       const theme = themeable(props.theme);
-      const componentClasses = ClassNames({
+      const componentClasses = classNames({
           "block": !inline,
           inline,
           disabled,

--- a/packages/react-atlas-core/src/checkbox/Checkbox.js
+++ b/packages/react-atlas-core/src/checkbox/Checkbox.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import ClassNames from 'classnames';
+import { classNames } from '../utils';
 import themeable from 'react-themeable';
 
 /**

--- a/packages/react-atlas-core/src/dialog/Dialog.js
+++ b/packages/react-atlas-core/src/dialog/Dialog.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import ClassNames from "classnames";
+import { classNames } from '../utils';
 import Overlay from "../overlay";
 import themeable from 'react-themeable';
 
@@ -96,4 +96,3 @@ ReactDOM.render(<App/>, mountNode);
 };
 
 export default Dialog;
-

--- a/packages/react-atlas-core/src/dialog/Dialog.js
+++ b/packages/react-atlas-core/src/dialog/Dialog.js
@@ -6,7 +6,7 @@ import themeable from 'react-themeable';
 const Dialog = ({body, active, type, children, className, onOverlayClick, ...props}) => {
 
     const theme = themeable(props.theme);
-    const componentClasses = ClassNames({
+    const componentClasses = classNames({
         inactive: !active,
         type,
         active,

--- a/packages/react-atlas-core/src/drawer/Drawer.js
+++ b/packages/react-atlas-core/src/drawer/Drawer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ClassNames from 'classnames';
+import { classNames } from '../utils';
 import Overlay from '../overlay';
 import themeable from 'react-themeable';
 

--- a/packages/react-atlas-core/src/drawer/Drawer.js
+++ b/packages/react-atlas-core/src/drawer/Drawer.js
@@ -5,7 +5,7 @@ import themeable from 'react-themeable';
 
 const Drawer = ({active, className, type, onOverlayClick, ...props}) => {
   const theme = themeable(props.theme);
-  const classes = ClassNames({
+  const classes = classNames({
     container: true,
     left: type == 'left',
     right: type == 'right',

--- a/packages/react-atlas-core/src/dropdown/Dropdown.js
+++ b/packages/react-atlas-core/src/dropdown/Dropdown.js
@@ -6,7 +6,7 @@ Copyright (c) 2015, Timothy Kempf <tim@kemp59f.info>
 */
 
 import React, { cloneElement, Component, PropTypes } from 'react';
-import classNames from 'classnames/bind';
+import { classNames } from '../utils';
 import DropdownTrigger from './DropdownTrigger';
 import DropdownContent from './DropdownContent';
 import { findDOMNode } from 'react-dom';

--- a/packages/react-atlas-core/src/dropdown/DropdownContent.js
+++ b/packages/react-atlas-core/src/dropdown/DropdownContent.js
@@ -5,7 +5,7 @@ https://github.com/Fauntleroy/react-simple-dropdown
 Copyright (c) 2015, Timothy Kempf <tim@kemp59f.info>
 */
 import React, { component, PropTypes } from 'react';
-import classNames from 'classnames/bind';
+import { classNames } from '../utils';
 import style from './dropdown.css';
 
 /**

--- a/packages/react-atlas-core/src/dropdown/DropdownList.js
+++ b/packages/react-atlas-core/src/dropdown/DropdownList.js
@@ -5,7 +5,7 @@ https://github.com/Fauntleroy/react-simple-dropdown
 Copyright (c) 2015, Timothy Kempf <tim@kemp59f.info>
 */
 import React, { component, PropTypes } from 'react';
-import classNames from 'classnames/bind';
+import { classNames } from '../utils';
 import style from './dropdown.css';
 
 /**

--- a/packages/react-atlas-core/src/dropdown/DropdownListItem.js
+++ b/packages/react-atlas-core/src/dropdown/DropdownListItem.js
@@ -5,7 +5,7 @@ https://github.com/Fauntleroy/react-simple-dropdown
 Copyright (c) 2015, Timothy Kempf <tim@kemp59f.info>
 */
 import React, { component, PropTypes } from 'react';
-import classNames from 'classnames/bind';
+import { classNames } from '../utils';
 import style from './dropdown.css';
 
 /**

--- a/packages/react-atlas-core/src/slider/Slider.js
+++ b/packages/react-atlas-core/src/slider/Slider.js
@@ -1,7 +1,7 @@
 import React, { PropTypes, Component } from 'react';
 import ReactDOM from 'react-dom';
 import themeable from 'react-themeable';
-import classNames from 'classnames/bind';
+import { classNames } from '../utils';
 import events from '../utils/events';
 import prefixer from '../utils/prefixer';
 import utils from '../utils';

--- a/packages/react-atlas-core/src/snackbar/Snackbar.js
+++ b/packages/react-atlas-core/src/snackbar/Snackbar.js
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import themeable from 'react-themeable';
 import Overlay from '../overlay';
-import classNames from 'classnames/bind';
+import { classNames } from '../utils';
 
 class Snackbar extends Component {
 

--- a/packages/react-atlas-core/src/switch/Switch.js
+++ b/packages/react-atlas-core/src/switch/Switch.js
@@ -1,8 +1,8 @@
 import React, { Component, PropTypes } from 'react';
 import themeable from 'react-themeable';
-import classNames from 'classnames/bind';
+import { classNames } from '../utils';
 
-class Switch extends React.Component {
+export default class Switch extends React.Component {
 
   render () {
 
@@ -107,4 +107,3 @@ Switch.styleguide = {
 </section>
 `
 };
-export default Switch;

--- a/packages/react-atlas-core/src/table/Table.js
+++ b/packages/react-atlas-core/src/table/Table.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import themeable from 'react-themeable';
-import classNames from 'classnames/bind';
+import { classNames } from '../utils';
 
 const Table = ({className, children, ...props}) => {
 

--- a/packages/react-atlas-core/src/table/Td.js
+++ b/packages/react-atlas-core/src/table/Td.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import themeable from 'react-themeable';
-import classNames from 'classnames/bind';
+import { classNames } from '../utils';
 
 const Td = ({className, children, ...props}) => {
 

--- a/packages/react-atlas-core/src/table/Th.js
+++ b/packages/react-atlas-core/src/table/Th.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import themeable from 'react-themeable';
-import classNames from 'classnames/bind';
+import { classNames } from '../utils';
 
 const Th = ({className, children, ...props}) => {
 	const theme = themeable(props.theme);

--- a/packages/react-atlas-core/src/tabs/Tab.js
+++ b/packages/react-atlas-core/src/tabs/Tab.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import themeable from 'react-themeable';
-import classNames from 'classnames/bind';
+import { classNames } from '../utils';
 
 /**
  * Individual Tab component used within `<Tabs>`. Can be disabled, hidden and also sent an onActive event trigger. Children become `<TabContent>`.
@@ -104,7 +104,7 @@ class TabsExample extends React.Component {
 }
 
 ReactDOM.render(<TabsExample />, mountNode);
-// } 
+// }
 `
 };
 

--- a/packages/react-atlas-core/src/tabs/TabContent.js
+++ b/packages/react-atlas-core/src/tabs/TabContent.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import themeable from 'react-themeable';
-import classNames from 'classnames/bind';
+import { classNames } from '../utils';
 
 /**
  * Used within the `<Tabs>` Component to programatically determine the content of any given tab. There probably isn't any reason for you to actually use `<TabContent>` directly.
@@ -78,7 +78,7 @@ class TabsExample extends React.Component {
 }
 
 ReactDOM.render(<TabsExample />, mountNode);
-// } 
+// }
 `
 };
 

--- a/packages/react-atlas-core/src/tabs/Tabs.js
+++ b/packages/react-atlas-core/src/tabs/Tabs.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import themeable from 'react-themeable';
-import classNames from 'classnames/bind';
+import { classNames } from '../utils';
 import Tab from "./Tab";
 import TabContent from "./TabContent";
 
@@ -111,7 +111,7 @@ class TabsExample extends React.Component {
 }
 
 ReactDOM.render(<TabsExample />, mountNode);
-// } 
+// }
 `
 };
 

--- a/packages/react-atlas-core/src/tooltip/Tooltip.js
+++ b/packages/react-atlas-core/src/tooltip/Tooltip.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import themeable from 'react-themeable';
-import classNames from 'classnames/bind';
+import { classNames } from '../utils';
 
 /*
  * A CSS driven tooltip that gives more information when an element it wraps is hovered over.
@@ -24,7 +24,7 @@ class Tooltip extends Component {
 
     const element = inline ? 'span' : 'div';
 
-    let props = { 
+    let props = {
       'data-tooltip': tooltip
     };
 
@@ -69,7 +69,7 @@ Tooltip.styleguide = {
     <Input label="hello" type="text" />
   </Tooltip>
   <p>Lorem ipsum dolor sit amet, <Tooltip tooltip="Tooltip inside a sentence" inline><strong>consectetur</strong></Tooltip> adipiscing elit.</p>
-</section>  
+</section>
 `
 };
 

--- a/packages/react-atlas-default-theme/package.json
+++ b/packages/react-atlas-default-theme/package.json
@@ -28,7 +28,6 @@
   "license": "MIT",
   "dependencies": {
     "blacklist": "^1.1.2",
-    "classnames": "^2.2.5",
     "react": "^15.0.2",
     "react-dom": "^15.0.2",
     "react-addons-css-transition-group": "^15.0.2",


### PR DESCRIPTION
Switch components to the classNames() in `react-atlas-core/src/utils/classNames.js` and remove classNames from the package.json files.