### PR TITLE
Update lerna from 2.0.0-beta.38 to 2.0.0-rc.3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "babel-preset-stage-1": "^6.22.0",
     "cross-spawn": "^5.1.0",
     "glob": "^7.1.1",
-    "lerna": "2.0.0-beta.38"
+    "lerna": "^2.0.0-rc.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This fixes a bug in lerna so we can build react-atlas on Windows machines using cygwin.