### PR TITLE
Create a separate dev and production build of react-atlas.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,22 +1,10 @@
 {
-  "presets": ["es2015", "react", "stage-1"],
+  "presets": [["es2015", { "modules": false }], "react", "stage-1"],
   "env": {
-
    "production": {
-      "plugins": [
-        [
-          "css-modules-transform", {
-            "generateScopedName": "ra_[name]__[local]",
-            "prepend": [
-              "postcss-import",
-              "postcss-cssnext"
-            ]
-          }
-        ],
-        ["transform-react-remove-statics", {
-            "propTypes": true,
-            "styleguide": true
-        }]
+      "plugins": ["transform-react-constant-elements",
+                  "transform-react-inline-elements",
+                  "transform-react-remove-prop-types"
       ]
     }
   }

--- a/buildPackages.js
+++ b/buildPackages.js
@@ -10,13 +10,21 @@ packages.push(packages.shift());
 
 packages.forEach(function(pack) {
   // ensure path has package.json
-  if (!fs.existsSync(path.join(pack, "package.json"))) return;
+  if(!fs.existsSync(path.join(pack, "package.json"))) return;
 
-  spawn.sync(pack + '/node_modules/webpack/bin/webpack.js', {
-    env: process.env,
-    cwd: pack,
-    stdio: "inherit"
-  });
+  if(process.env.NODE_ENV === 'production') {
+  	spawn.sync(pack + '/node_modules/webpack/bin/webpack.js', ['-p'], {
+      env: process.env,
+      cwd: pack,
+      stdio: "inherit"
+    });
+  } else {
+    spawn.sync(pack + '/node_modules/webpack/bin/webpack.js', {
+      env: process.env,
+      cwd: pack,
+      stdio: "inherit"
+    });
+  }
  });
 
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "babel-plugin-transform-react-constant-elements": "^6.23.0",
+    "babel-plugin-transform-react-inline-elements": "^6.22.0",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.2",
     "react": "^15.4.2",
     "react-autosuggest": "^3.7.3",
     "react-dom": "^15.4.2"

--- a/packages/react-atlas-core/webpack.config.js
+++ b/packages/react-atlas-core/webpack.config.js
@@ -1,7 +1,7 @@
 var path = require('path');
 var webpack = require('webpack');
 
-module.exports = {
+let config = {
   entry: [
     './src/index.js'
   ],
@@ -35,4 +35,29 @@ module.exports = {
       }
     ],
   },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        'NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+      }
+    }),
+    new webpack.optimize.UglifyJsPlugin({
+      compress: {
+        warnings: false
+      }
+    })
+  ]
 };
+
+if(process.env.NODE_ENV === "production") {
+  config.plugins.push(new webpack.optimize.UglifyJsPlugin({
+    compress: {
+      warnings: false
+    }
+  }))
+  config.plugins.push(new webpack.optimize.AggressiveMergingPlugin());
+}
+
+module.exports = function() {
+  return config;
+}

--- a/packages/react-atlas-core/webpack.config.js
+++ b/packages/react-atlas-core/webpack.config.js
@@ -40,11 +40,6 @@ let config = {
       'process.env': {
         'NODE_ENV': JSON.stringify(process.env.NODE_ENV)
       }
-    }),
-    new webpack.optimize.UglifyJsPlugin({
-      compress: {
-        warnings: false
-      }
     })
   ]
 };

--- a/packages/react-atlas-default-theme/webpack.config.js
+++ b/packages/react-atlas-default-theme/webpack.config.js
@@ -2,7 +2,7 @@ var path = require('path');
 const webpack = require('webpack');
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
 
-module.exports = {
+let config = {
   entry: [
     './src/index.js'
   ],
@@ -35,5 +35,23 @@ module.exports = {
   },
   plugins: [
     new ExtractTextPlugin("atlasThemes.min.css"),
+    new webpack.DefinePlugin({
+      'process.env': {
+        'NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+      }
+    })
   ]
 };
+
+if(process.env.NODE_ENV === "production") {
+  config.plugins.push(new webpack.optimize.UglifyJsPlugin({
+    compress: {
+      warnings: false
+    }
+  }))
+  config.plugins.push(new webpack.optimize.AggressiveMergingPlugin());
+}
+
+module.exports = function() {
+  return config;
+}

--- a/packages/react-atlas/webpack.config.js
+++ b/packages/react-atlas/webpack.config.js
@@ -1,7 +1,7 @@
 var path = require('path');
 var webpack = require('webpack');
 
-module.exports = {
+let config =  {
   entry: [
     './src/index.js'
   ],
@@ -25,4 +25,24 @@ module.exports = {
       },
     ],
   },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        'NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+      }
+    })
+  ]
 };
+
+if(process.env.NODE_ENV === "production") {
+  config.plugins.push(new webpack.optimize.UglifyJsPlugin({
+    compress: {
+      warnings: false
+    }
+  }))
+  config.plugins.push(new webpack.optimize.AggressiveMergingPlugin());
+}
+
+module.exports = function() {
+  return config;
+}


### PR DESCRIPTION
Use `NODE_ENV=dev` or leave NODE_ENV unset for development or set `NODE_ENV=production` for production builds.