### PR TITLE
Fix for babel warning

### DIFF
--- a/packages/react-atlas-core/webpack.config.js
+++ b/packages/react-atlas-core/webpack.config.js
@@ -28,9 +28,7 @@ let config = {
         exclude: /(node_modules|bower_components)/,
         use: {
           loader: 'babel-loader',
-          options: {
-         
-          }
+          query: {compact: true}
         }
       }
     ],


### PR DESCRIPTION
This commit fixes the warning ```[BABEL] Note: The code generator has deoptimised the styling of "C:/dev/react-atlas/packages/react-atlas-core/lib/index.js" as it exceeds the max of "500KB".```