### PR TITLE
Proptypes

### DIFF
--- a/packages/react-atlas/src/codegen.config.js
+++ b/packages/react-atlas/src/codegen.config.js
@@ -72,7 +72,9 @@ let devTemplate = warningMessage;
 devTemplate +=
   "import CSSModules from 'react-css-modules';" +
   eol +
-  "import React, { PropTypes } from 'react';" +
+  "import React from 'react';" +
+  eol + 
+  "import PropTypes from 'prop-types';" +
   eol +
   "import { {{=it.component.name}}Core } from 'react-atlas-core';" +
   eol +


### PR DESCRIPTION
Have codegen use the proptypes package to avoid a react warning.