### PR TITLE
Make cleaning node_modules a single command instead of 3 serparte com…

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ $ npm run coverage        // Runs test suite with code coverage.
 $ npm run format          // Format all code with prettier.
 $ npm run lint            // Lint code with eslint.
 $ npm run setup           // Builds react-atlas.
-$ npm run codegen   // Runs just the code generator.
+$ npm run codegen         // Runs just the code generator.
+$ npm run clean           // Clean all node_modules folders.
 
 ```
 For more in depth information on development check out our contributors [readme](readme/CONTRIBUTING.md#contributing).

--- a/cleanPackages.js
+++ b/cleanPackages.js
@@ -1,0 +1,14 @@
+var spawn = require("cross-spawn");
+
+spawn.sync('lerna', ['clean', '--yes'], {
+  env: process.env,
+  stdio: "inherit"
+});
+
+spawn.sync('rimraf', ['./node_modules'], {
+  env: process.env,
+  stdio: "inherit"
+});
+
+
+

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lerna:bootstrap": "lerna bootstrap",
     "lerna:updated": "lerna updated",
     "lerna:publish": "lerna publish",
-    "clean": "lerna clean",
+    "clean": "node cleanPackages.js",
     "packages:build": "node buildPackages.js",
     "setup": "npm run lerna:init && npm run lerna:bootstrap && npm run packages:build",
     "codegen": "node packages/react-atlas/src/codegen.js",
@@ -61,6 +61,7 @@
     "lerna": "^2.0.0-rc.5",
     "prettier": "^1.3.1",
     "react-addons-test-utils": "^15.5.1",
+    "rimraf": "^2.6.1",
     "sinon": "^2.2.0"
   },
   "repository": {


### PR DESCRIPTION
…mands.

Brings in rimraf as a dev dependency and adds clean command to readme.