### PR TITLE
Switch to react-test-renderer from react-test-utils to avoid warning …

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "babel-plugin-transform-react-constant-elements": "^6.23.0",
     "babel-plugin-transform-react-inline-elements": "^6.22.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.2",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4"
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",
@@ -62,7 +62,7 @@
     "jest": "^20.0.1",
     "lerna": "^2.0.0",
     "prettier": "^1.3.1",
-    "react-addons-test-utils": "^15.5.1",
+    "react-test-renderer": "^15.6.1",
     "rimraf": "^2.6.1",
     "sinon": "^2.2.0"
   },

--- a/packages/react-atlas-core/package.json
+++ b/packages/react-atlas-core/package.json
@@ -22,8 +22,8 @@
     "classnames": "^2.2.5",
     "inputmask-core": "^2.2.0",
     "proptypes": "^1.0.0",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4"
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1"
   },
   "devDependencies": {
     "babel-core": "^6.24.1",

--- a/packages/react-atlas-default-theme/package.json
+++ b/packages/react-atlas-default-theme/package.json
@@ -19,8 +19,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4"
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1"
   },
   "devDependencies": {
     "css-loader": "^0.28.1",

--- a/packages/react-atlas/package.json
+++ b/packages/react-atlas/package.json
@@ -26,7 +26,7 @@
     "babel-loader": "^7.0.0",
     "react-docgen": "^2.14.1",
     "dot": "^1.1.1",
-    "react": "^15.5.4",
+    "react": "^15.6.1",
     "react-atlas-core": "^0.0.10",
     "react-atlas-default-theme": "^0.0.10",
     "react-css-modules": "^4.1.0",


### PR DESCRIPTION
…in test output. Bump react to 15.6.1 to satisfy react-test-renderer dependency.