### PR TITLE
Fix bug where isValid could become undefined when the component was c…

### DIFF
--- a/packages/react-atlas-core/src/Dropdown/Dropdown.js
+++ b/packages/react-atlas-core/src/Dropdown/Dropdown.js
@@ -41,8 +41,9 @@ class Dropdown extends React.PureComponent {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.isValid !== this.state.isValid) {
-      this.setState({ isValid: nextProps.isValid });
+    if (typeof nextProps.isValid !== 'undefined' &&
+        nextProps.isValid !== this.state.isValid) {
+          this.setState({ isValid: nextProps.isValid });
     }
   }
 

--- a/packages/react-atlas-core/src/TextField/TextField.js
+++ b/packages/react-atlas-core/src/TextField/TextField.js
@@ -16,8 +16,9 @@ class TextField extends React.PureComponent {
   }
 
   componentWillReceiveProps(nextProps) {
-    if(nextProps.isValid !== this.state.valid) {
-      this.setState({"valid": nextProps.isValid});
+    if (typeof nextProps.isValid !== 'undefined' &&
+        nextProps.isValid !== this.state.isValid) {
+          this.setState({ isValid: nextProps.isValid });
     }
   }
 


### PR DESCRIPTION
…licked and selected. This caused the error message to fire when the component was in fact valid.