### PR TITLE
Fix Dropdown component styling.

### DIFF
--- a/packages/react-atlas-core/src/Dropdown/Dropdown.js
+++ b/packages/react-atlas-core/src/Dropdown/Dropdown.js
@@ -271,14 +271,14 @@ class Dropdown extends React.PureComponent {
       this.props.children,
       (child, i) => {
         let childClasses = cx({
-          ra_dropdown__selected: i === this.state.index,
-          ra_dropdown__firstChild: i === 0,
-          ra_dropdown__lastChild: i === count - 1
+          ra_Dropdown__selected: i === this.state.index,
+          ra_Dropdown__firstChild: i === 0,
+          ra_Dropdown__lastChild: i === count - 1
         });
         let kid = (
           <li
             key={i}
-            className={"ra_dropdown__item " + childClasses}
+            className={"ra_Dropdown__item " + childClasses}
             styleName={"default-font"}
             onMouseDown={e => {
               // onMouseDown fires before onBlur. If changed to onClick it will fire after onBlur and not work.


### PR DESCRIPTION
Uppercase hardcoded styles on dropdown button and dropdown items. Needs to be upper cased because the styles folder now has upper cased stylesheets so they build on FreeBSD and Linux.