### PR TITLE
Fix static builds of atlas. Updates react-datepicker version from 0.5…

### DIFF
--- a/packages/react-atlas-core/package.json
+++ b/packages/react-atlas-core/package.json
@@ -25,7 +25,7 @@
     "moment": "^2.19.1",
     "proptypes": "^1.0.0",
     "react": "^15.6.2",
-    "react-datepicker": "^0.56.0",
+    "react-datepicker": "^0.60.2",
     "react-dom": "^15.6.2",
     "react-dropzone": "^4.2.1"
   },


### PR DESCRIPTION
…4.0 to 0.60.2 This fixes among other things a regression in popper.js that causes static builds to fail. Fixes #476