### PR TITLE
added viewbox attribute to svg element

### DIFF
--- a/packages/react-atlas-core/src/ProgressBar/ProgressBar.js
+++ b/packages/react-atlas-core/src/ProgressBar/ProgressBar.js
@@ -47,7 +47,7 @@ class ProgressBar extends React.PureComponent {
 
   renderCircular() {
     return (
-      <svg styleName={"circle"}>
+      <svg styleName={"circle"} viewBox="0 0 60 60">
         <circle
           styleName={"path"}
           style={this.circularStyle()}


### PR DESCRIPTION
Previously, adding height/width to style of ProgressBar resulted in some wonky looking spinners.  ViewBox attribute ensures that things scale nicely.

Jira issue: ATLAS-24