### PR TITLE
adding ProgressBar examples to docs, fixing typo in TextField docs

### DIFF
--- a/packages/react-atlas-core/src/ProgressBar/README.md
+++ b/packages/react-atlas-core/src/ProgressBar/README.md
@@ -1,3 +1,19 @@
 Basic Progress Bar:
 
 	<ProgressBar/>
+
+Basic Progress Bar with custom color:
+
+    <ProgressBar color="red"/>
+
+Determinate Progress Bar:
+
+    <ProgressBar mode="determinate" value="60"/>
+
+Circular Progress Bar:
+
+    <ProgressBar type="circular"/>
+
+Circular determinate Progress Bar with custom color:
+
+    <ProgressBar type="circular" mode="determinate" value="60" color="#4da547"/>

--- a/packages/react-atlas-core/src/TextField/TextField.js
+++ b/packages/react-atlas-core/src/TextField/TextField.js
@@ -344,7 +344,7 @@ TextField.propTypes = {
   "linkRight": PropTypes.bool,
     /** The text of the link button. **/
   "linkText": PropTypes.string,
-    /** Callback to call when link buttonis clicked. **/
+    /** Callback to call when link button is clicked. **/
   "linkOnClick": PropTypes.func,
     /** HREF to set on the link button. **/
   "href": PropTypes.string,


### PR DESCRIPTION
Didn't document multicolor or min/max or transition duration - not sure how those are supposed to work.  Added examples for custom color, determinate, circular and fixed a missing space typo in the docs for TextField