### PR TITLE
consistency updates for Avatar

### DIFF
--- a/packages/react-atlas-core/src/Avatar/Avatar.js
+++ b/packages/react-atlas-core/src/Avatar/Avatar.js
@@ -71,7 +71,7 @@ class Avatar extends React.PureComponent {
     }
 
     return (
-      <div className={cx(className)} style={style} styleName={"avatar"}>
+      <div title={title} className={cx(className)} style={style} styleName={"avatar"}>
         {kids}
         {avatar}
       </div>
@@ -102,7 +102,7 @@ Avatar.propTypes = {
    */
   "image": PropTypes.string,
   /**
-   * A string. Avatar will use First letter of the string.
+   * A string. Avatar will use the first letter of the string.
    * @examples "Nathan" will output "N"
    */
   "title": PropTypes.string,

--- a/packages/react-atlas-default-theme/src/Avatar/Avatar.css
+++ b/packages/react-atlas-default-theme/src/Avatar/Avatar.css
@@ -40,4 +40,5 @@
   display: block;
   width: 100%;
   line-height: 3rem;
+  cursor: default;
 }

--- a/packages/react-atlas-tests/avatar/__tests__/__snapshots__/avatar.test.js.snap
+++ b/packages/react-atlas-tests/avatar/__tests__/__snapshots__/avatar.test.js.snap
@@ -5,6 +5,7 @@ exports[`Test correct render Test correct render 1`] = `
   className=""
   style={undefined}
   styleName="avatar"
+  title="testTitle"
 >
   <img
     onError={[Function]}


### PR DESCRIPTION
- updated letter css so its cursor would be consistent with other avatar types
- added title attribute to wrapper element so that all avatars will display title on hover if title is supplied (previously this only happened on image)
- fixed a typo in documentation