### PR TITLE
Atlas-36, conform tooltip to styleguide

### DIFF
--- a/packages/react-atlas-core/src/Tooltip/Tooltip.js
+++ b/packages/react-atlas-core/src/Tooltip/Tooltip.js
@@ -46,10 +46,10 @@ class Tooltip extends React.PureComponent {
     tooltipClasses = cx({
       "tooltip": true,
       "active": this.state.active,
-      "tooltip-bottom":
-        position !== "left" && position !== "top" && position !== "right",
+      "tooltip-top":
+        position !== "left" && position !== "bottom" && position !== "right",
       "tooltip-left": position === "left",
-      "tooltip-top": position === "top",
+      "tooltip-bottom": position === "bottom",
       "tooltip-right": position === "right"
     });
 
@@ -64,6 +64,7 @@ class Tooltip extends React.PureComponent {
       <div
         style={style}
         data-tooltip={this.state.tooltip}
+        role="tooltip"
         styleName={componentClasses}
         className={cx(className)}
         onMouseEnter={e => {
@@ -109,8 +110,8 @@ Tooltip.propTypes = {
    */
   "disabled": PropTypes.bool,
   /**
-   * For positioning the tooltip to top, left, right or bottom.  Default is to the bottom
-   * @example <Tooltip position="top"/>
+   * For positioning the tooltip to top, left, right or bottom.  Default is top.
+   * @example <Tooltip position="left"/>
    */
   "position": PropTypes.string,
   /**
@@ -125,7 +126,7 @@ Tooltip.propTypes = {
 Tooltip.defaultProps = {
   "className": "",
   "children": "",
-  "icon": "fa fa-info-circle",
+  "icon": "fa fa-question-circle",
   "disabled": false,
   "text": "",
   "delay": null

--- a/packages/react-atlas-default-theme/src/Tooltip/Tooltip.css
+++ b/packages/react-atlas-default-theme/src/Tooltip/Tooltip.css
@@ -1,7 +1,7 @@
-
+@import '../styles/variables.css';
 /* Base styles for the element that has a tooltip */
 .tooltip {
-  composes: charcoal from '../styles.css';
+  composes: gray from '../styles.css';
   composes: default-font from '../styles.css';
   position: relative;
   display: inline-block;
@@ -9,7 +9,6 @@
 }
 
 .tooltip > i , .block > i {
-  opacity: 0.2;
   font-size: 1rem !important;
   cursor: pointer;
 }
@@ -70,11 +69,11 @@
   z-index: 1000;
   padding: 8px;
   width: 160px;
-  background-color: #000;
-  background-color: hsla(0, 0%, 20%, 0.9);
-  color: #fff;
+  background-color: var(--blue);
+  color: var(--white);
   font-size: 14px;
   line-height: 1.2;
+  text-align:center;
 }
 
 /* Directions */
@@ -91,9 +90,8 @@
 .tooltip:before,
 .tooltip-top:before {
   margin-left: -6px;
-  margin-bottom: -12px;
-  border-top-color: #000;
-  border-top-color: hsla(0, 0%, 20%, 0.9);
+  margin-bottom: -11.5px;
+  border-top-color: var(--blue);
 }
 
 /* Horizontally align top/bottom tooltips */
@@ -123,11 +121,10 @@
 
 .tooltip-left:before {
   margin-left: 0;
-  margin-right: -12px;
+  margin-right: -10.5px;
   margin-bottom: -5px;
   border-top-color: transparent;
-  border-left-color: #000;
-  border-left-color: hsla(0, 0%, 20%, 0.9);
+  border-left-color: var(--blue);
 }
 
 .tooltip-left:hover:before,
@@ -148,11 +145,10 @@
 }
 
 .tooltip-bottom:before {
-  margin-top: -12px;
+  margin-top: -11px;
   margin-bottom: 0;
   border-top-color: transparent;
-  border-bottom-color: #000;
-  border-bottom-color: hsla(0, 0%, 20%, 0.9);
+  border-bottom-color: var(--blue);
 }
 
 .tooltip-bottom:hover:before,
@@ -173,10 +169,9 @@
 
 .tooltip-right:before {
   margin-bottom: -5px;
-  margin-left: -12px;
+  margin-left: -11.5px;
   border-top-color: transparent;
-  border-right-color: #000;
-  border-right-color: hsla(0, 0%, 20%, 0.9);
+  border-right-color: var(--blue);
 }
 
 .tooltip-right:hover:before,

--- a/packages/react-atlas-tests/tooltip/__tests__/__snapshots__/tooltip.test.js.snap
+++ b/packages/react-atlas-tests/tooltip/__tests__/__snapshots__/tooltip.test.js.snap
@@ -6,6 +6,7 @@ exports[`Test Tooltip component render Render correctly 1`] = `
   data-tooltip=""
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
+  role="tooltip"
   style={undefined}
   styleName="block tooltip tooltip-top"
 >


### PR DESCRIPTION
Tooltip component should be updated to match styleguide:

Icon should use a question mark in circle icon
Icon color should be #BEBEBE
Tooltip element should have a role attribute with value "tooltip"
Tooltip text should be background color #003058, color #FFFFFF
Tooltip text default placement should be top