### PR TITLE
fixes for atlas 34 and 35 stories

### DIFF
--- a/packages/react-atlas-core/src/Checkbox/Checkbox.js
+++ b/packages/react-atlas-core/src/Checkbox/Checkbox.js
@@ -137,7 +137,7 @@ class Checkbox extends React.PureComponent {
               id={id}
               name={name}
               /* Hardcode classes for InputCore because classes on styleName will not
-               * be evaluated because were using InputCore not Input.  */
+               * be evaluated because we are using InputCore rather than Input.  */
               className={
                 "ra_Input__checkbox ra_styles__marg-b-1 ra_Input__max ra_Input__opacity"
               }

--- a/packages/react-atlas-core/src/Input/Input.js
+++ b/packages/react-atlas-core/src/Input/Input.js
@@ -283,8 +283,7 @@ class Input extends React.PureComponent {
       "large": large,
       "max": !small && !medium && !large,
       disabled,
-      hidden,
-      "opacity": true
+      hidden
     });
 
     let eventHandlers = {

--- a/packages/react-atlas-core/src/Radio/Radio.js
+++ b/packages/react-atlas-core/src/Radio/Radio.js
@@ -119,7 +119,7 @@ class Radio extends React.PureComponent {
               name={name}
               value={value}
               /* Hardcode classes for InputCore because classes on styleName will not
-               * be evaluated because were using InputCore not Input.  */
+               * be evaluated because we are using InputCore rather than Input.  */
               className={"ra_Input__max ra_Input__opacity"}
             />
             <div styleName={radioClass}>

--- a/packages/react-atlas-core/src/TextArea/README.md
+++ b/packages/react-atlas-core/src/TextArea/README.md
@@ -51,6 +51,6 @@
 
     <TextArea onChange={ () => { alert('onChange executed!'); } }/>
 
-###### TextArea Tooltip requires Header:
+###### TextArea Tooltip requires Label:
 
-    <TextArea header="tooltip header" tooltip="tip of the tool"/>
+    <TextArea label="tooltip header" tooltip="tip of the tool"/>

--- a/packages/react-atlas-core/src/TextField/README.md
+++ b/packages/react-atlas-core/src/TextField/README.md
@@ -33,7 +33,7 @@
 
     <TextField placeholder="Enter product details here..."/>
 
-###### HTML5 types texfields (default: "text"):
+###### HTML5 types textfields (default: "text"):
 
 	<div>
 		<TextField type="email" label="Email"/>

--- a/packages/react-atlas-default-theme/src/Input/Input.css
+++ b/packages/react-atlas-default-theme/src/Input/Input.css
@@ -3,6 +3,8 @@
 	clear: both;
 }
 input.opacity[type="checkbox"], input.opacity[type="radio"] {
+	/*used by Radio and Checkbox modules, even though not used in Input itself */
+	/*this needs to stay here to avoid display issues with those modules in IE*/
 	opacity: 0;
 }
 .input {

--- a/packages/react-atlas-tests/TextArea/__tests__/textArea.test.js
+++ b/packages/react-atlas-tests/TextArea/__tests__/textArea.test.js
@@ -63,7 +63,7 @@ describe("Testing TextArea component", () => {
 	it("TextArea component - Simple text inserted", function() {
 		const textArea = mount(< TextAreaCore maxLength={10} />);
 		textArea.state().value = 'iou';
-		let input = textArea.findWhere((n) => {return n.props().styleName == 'input max opacity'});
+		let input = textArea.findWhere((n) => {return n.props().styleName == 'input max'});
 		input.simulate('focus');
 		input.simulate('change');
 		expect(textArea.state().remaining).toEqual(7);
@@ -73,7 +73,7 @@ describe("Testing TextArea component", () => {
 	it("TextArea component - Simple text inserted(no maxLenght)", function() {
 		const textArea = mount(< TextAreaCore />);
 		textArea.state().value = 'iou';
-		let input = textArea.findWhere((n) => {return n.props().styleName == 'input max opacity'});
+		let input = textArea.findWhere((n) => {return n.props().styleName == 'input max'});
 		input.simulate('focus');
 		input.simulate('change');
 		expect(textArea.state().value).toEqual('iou');
@@ -82,7 +82,7 @@ describe("Testing TextArea component", () => {
 	it("TextArea component - Simple text inserted(with onChange prop) " , function() {
 		const textArea = mount(< TextAreaCore maxLength={10} onChange={() => {console.log('[INFO]: Inside onChange'); return true} }/>);
 		textArea.state().value = 'iou';
-		let input = textArea.findWhere((n) => {return n.props().styleName == 'input max opacity'});
+		let input = textArea.findWhere((n) => {return n.props().styleName == 'input max'});
 		input.simulate('focus');
 		input.simulate('change');
 		expect(textArea.state().remaining).toEqual(7);

--- a/packages/react-atlas-tests/checkbox/__tests__/__snapshots__/checkbox.test.js.snap
+++ b/packages/react-atlas-tests/checkbox/__tests__/__snapshots__/checkbox.test.js.snap
@@ -30,7 +30,7 @@ exports[`Test checkbox component renders correctly 1`] = `
         onKeyPress={[Function]}
         onPaste={[Function]}
         style={undefined}
-        styleName="checkbox max opacity"
+        styleName="checkbox max"
         type="checkbox"
       />
       <div

--- a/packages/react-atlas-tests/checkboxGroup/__tests__/__snapshots__/checkboxGroup.test.js.snap
+++ b/packages/react-atlas-tests/checkboxGroup/__tests__/__snapshots__/checkboxGroup.test.js.snap
@@ -38,7 +38,7 @@ exports[`Test CheckboxGroup component - the bascis Test renders correctly 1`] = 
           onKeyPress={[Function]}
           onPaste={[Function]}
           style={undefined}
-          styleName="checkbox max opacity"
+          styleName="checkbox max"
           type="checkbox"
         />
         <div
@@ -70,7 +70,7 @@ exports[`Test CheckboxGroup component - the bascis Test renders correctly 1`] = 
           onKeyPress={[Function]}
           onPaste={[Function]}
           style={undefined}
-          styleName="checkbox max opacity"
+          styleName="checkbox max"
           type="checkbox"
         />
         <div
@@ -102,7 +102,7 @@ exports[`Test CheckboxGroup component - the bascis Test renders correctly 1`] = 
           onKeyPress={[Function]}
           onPaste={[Function]}
           style={undefined}
-          styleName="checkbox max opacity"
+          styleName="checkbox max"
           type="checkbox"
         />
         <div
@@ -134,7 +134,7 @@ exports[`Test CheckboxGroup component - the bascis Test renders correctly 1`] = 
           onKeyPress={[Function]}
           onPaste={[Function]}
           style={undefined}
-          styleName="checkbox max opacity"
+          styleName="checkbox max"
           type="checkbox"
         />
         <div

--- a/packages/react-atlas-tests/input/__tests__/__snapshots__/input.test.js.snap
+++ b/packages/react-atlas-tests/input/__tests__/__snapshots__/input.test.js.snap
@@ -14,7 +14,7 @@ exports[`Test Input component render Render correctly 1`] = `
     onKeyPress={[Function]}
     onPaste={[Function]}
     placeholder="Text here"
-    styleName="input small opacity"
+    styleName="input small"
     type="text"
     value="Value"
   />

--- a/packages/react-atlas-tests/radio/__tests__/__snapshots__/radio.test.js.snap
+++ b/packages/react-atlas-tests/radio/__tests__/__snapshots__/radio.test.js.snap
@@ -32,7 +32,7 @@ exports[`Test Radio component render Render correctly 1`] = `
           onKeyPress={[Function]}
           onPaste={[Function]}
           placeholder={undefined}
-          styleName="max opacity"
+          styleName="max"
           type="radio"
           value="checkedRadio"
         />

--- a/packages/react-atlas-tests/radioGroup/__tests__/__snapshots__/radioGroup.test.js.snap
+++ b/packages/react-atlas-tests/radioGroup/__tests__/__snapshots__/radioGroup.test.js.snap
@@ -37,7 +37,7 @@ exports[`Test RadioGroup component render Render correctly 1`] = `
             onKeyPress={[Function]}
             onPaste={[Function]}
             placeholder={undefined}
-            styleName="max opacity"
+            styleName="max"
             type="radio"
             value="first"
           />
@@ -83,7 +83,7 @@ exports[`Test RadioGroup component render Render correctly 1`] = `
             onKeyPress={[Function]}
             onPaste={[Function]}
             placeholder={undefined}
-            styleName="max opacity"
+            styleName="max"
             type="radio"
             value="second"
           />
@@ -125,7 +125,7 @@ exports[`Test RadioGroup component render Render correctly 1`] = `
             onKeyPress={[Function]}
             onPaste={[Function]}
             placeholder={undefined}
-            styleName="max opacity"
+            styleName="max"
             type="radio"
             value="third"
           />
@@ -167,7 +167,7 @@ exports[`Test RadioGroup component render Render correctly 1`] = `
             onKeyPress={[Function]}
             onPaste={[Function]}
             placeholder={undefined}
-            styleName="max opacity"
+            styleName="max"
             type="radio"
             value="fourth"
           />
@@ -209,7 +209,7 @@ exports[`Test RadioGroup component render Render correctly 1`] = `
             onKeyPress={[Function]}
             onPaste={[Function]}
             placeholder={undefined}
-            styleName="max opacity"
+            styleName="max"
             type="radio"
             value="fifth"
           />
@@ -251,7 +251,7 @@ exports[`Test RadioGroup component render Render correctly 1`] = `
             onKeyPress={[Function]}
             onPaste={[Function]}
             placeholder={undefined}
-            styleName="max opacity"
+            styleName="max"
             type="radio"
             value="sixth"
           />

--- a/packages/react-atlas-tests/switch/__tests__/__snapshots__/switch.test.js.snap
+++ b/packages/react-atlas-tests/switch/__tests__/__snapshots__/switch.test.js.snap
@@ -18,7 +18,7 @@ exports[`Test switch component render Render correctly 1`] = `
     onKeyPress={[Function]}
     onPaste={[Function]}
     style={undefined}
-    styleName="checkbox max opacity"
+    styleName="checkbox max"
     type="checkbox"
   />
   <div


### PR DESCRIPTION
fixes jira stories 34 and 35.  We were adding a class to Input that had opacity set to 0 for checkbox and radio, so regular Input examples for checkbox and radio were not displaying.  Removed the class for Input, but it is still available and referenced by Checkbox and Radio - so I added a comment regarding that in the CSS.  Updated snapshots and tests that were looking for opacity css class.  Manually verified that Input, Checkbox, CheckboxGroup, Radio, RadioGroup, Switch, TextField and TextArea all still appear correctly in docs in Chrome, FF, IE Edge, and IE 10.  If other versions of IE should be tested, let me know.

Also made some minor typo corrections to docs for TextField and TextArea.