### PR TITLE
Atlas-33 fix doc example for Input custom validation on text field

### DIFF
--- a/packages/react-atlas-core/src/Input/README.md
+++ b/packages/react-atlas-core/src/Input/README.md
@@ -34,7 +34,7 @@ Input component should be used as core part of other components such as TextFiel
 
     <Input type="text"
          large
-         validator={this.validateTest}
+         validator={validateTest}
          errorText="Custom validation message"/>
 
 ###### Masked text input:


### PR DESCRIPTION
this fixes the doc example but further illustrates an issue Derek and I were looking into yesterday - the composes  on Input.css aren't working.  In addition to just making Input a bit ugly, it also means we've been adding css to modules that use Input where we probably wouldn't need to if the Input.css was actually composing correctly.