### PR TITLE
Documentation fixes for Avatar and Accordion

### DIFF
--- a/packages/react-atlas-core/src/Accordion/Accordion.js
+++ b/packages/react-atlas-core/src/Accordion/Accordion.js
@@ -131,53 +131,49 @@ Accordion.propTypes = {
    * @examples "SomeName", <Accordion>{child}{child}</Accordion>
    */
   "children": PropTypes.node,
-  /** An Object, array, or string of CSS classes to apply to accordion.*/
+  /** CSS classes to apply to Accordion.*/
   "className": PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.object,
     PropTypes.array
   ]),
   /**
-   * A string. Accordion will use title prop from each child as the title for header of each accordion
-   * @examples <Accordion><div title={title 1}>value 1</div><div title={title 2}>value 2</div></Accordion>
+   * When true, Accordion component is disabled.
    */
-  "title": PropTypes.string,
+  "disabled": PropTypes.bool,
   /**
-   * multiOpen
-   * boolean property.  Accordion will allow multiple open panels with this set to true
-   * @examples <Accordion multiOpen={true}>{children}</Accordion>
-   */
-  "multiOpen": PropTypes.bool,
-  /**
-   * expandAll
-   * boolean property.  Accordion will add an "expand all" link which when clicked open all panels or collapse all panels
+   * When true, Accordion will display "expand all" link that will open all panels.
    * @examples <Accordion expandAll={true}>{children}</Accordion>
    */
   "expandAll": PropTypes.bool,
   /**
-   * expanded
-   * boolean property.  Accordion will expand this child on load
+   * Accordion will use the expanded prop from each child to determine if the child will be expanded on load.
    * @examples <Accordion><div>value 1</div><div expanded>value 2</div></Accordion>
    */
   "expanded": PropTypes.bool,
   /**
-   * titlePosition
-   * string property. Accordion will set the title text position based on this property
+   * When true, Accordion will allow multiple open panels.
+   * @examples <Accordion multiOpen={true}>{children}</Accordion>
+   */
+  "multiOpen": PropTypes.bool,
+  /**
+   * Pass inline styles here.
+   */
+  "style": PropTypes.object,
+  /**
+   * Accordion will use title prop from each child as the title for that child's header.
+   * @examples <Accordion><div title={title 1}>value 1</div><div title={title 2}>value 2</div></Accordion>
+   */
+  "title": PropTypes.string,
+  /**
+   * Sets the Accordion's title text position left, right, or center.
    * @examples <Accordion titlePosition={left}>{children}</Accordion>
    */
   "titlePosition": PropTypes.string,
   /**
-   * The width of the accordion as a string or number.
+   * Sets the width of the Accordion.
    */
-  "width": PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  /**
-   * A boolean to disable or not disable the accordion component.
-   */
-  "disabled": PropTypes.bool,
-  /**
-   * Pass inline styles here.
-   */
-  "style": PropTypes.object
+  "width": PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 };
 
 Accordion.defaultProps = {

--- a/packages/react-atlas-core/src/Accordion/README.md
+++ b/packages/react-atlas-core/src/Accordion/README.md
@@ -9,7 +9,7 @@ Accordion:
      </Accordion>
 
 
-Accordion with expand all:
+Accordion with expandAll:
 
      <Accordion expandAll>
           <Panel title="First">Lorem ipsum dolor sit amet, cum alienum splendide te, has ad possim equidem, ad novum insolens usu.</Panel>
@@ -23,21 +23,21 @@ Accordion with multiOpen functionality:
           <Panel title="Second">Lorem ipsum dolor sit amet, cum alienum splendide te, has ad possim equidem, ad novum insolens usu.</Panel>
      </Accordion>
 
-Accordion with Width set in props as number (This is translated to NUMBERpx):
+Accordion with width set in props as number (This is translated to NUMBERpx):
 
      <Accordion width={400}>
           <Panel title="First">Lorem ipsum dolor sit amet, cum alienum splendide te, has ad possim equidem, ad novum insolens usu.</Panel>
           <Panel title="Second">Lorem ipsum dolor sit amet, cum alienum splendide te, has ad possim equidem, ad novum insolens usu.</Panel>
      </Accordion>
 
-Accordion with Width set in props as a string:
+Accordion with width set in props as a string:
 
      <Accordion width='50rem'>
           <Panel title="First">Lorem ipsum dolor sit amet, cum alienum splendide te, has ad possim equidem, ad novum insolens usu.</Panel>
           <Panel title="Second">Lorem ipsum dolor sit amet, cum alienum splendide te, has ad possim equidem, ad novum insolens usu.</Panel>
      </Accordion>
 
-Accordion with defined open panel:
+Accordion with defined panel:
 
      <Accordion>
           <Panel title="First">Lorem ipsum dolor sit amet, cum alienum splendide te, has ad possim equidem, ad novum insolens usu.</Panel>
@@ -51,3 +51,11 @@ Accordion with disabled prop:
           <Panel title="Second">Lorem ipsum dolor sit amet, cum alienum splendide te, has ad possim equidem, ad novum insolens usu.</Panel>
           <Panel title="Third">this is the third panel</Panel>
      </Accordion>
+
+ Accordion with titlePosition set to "center":
+
+      <Accordion titlePosition="center">
+           <Panel title="First">Lorem ipsum dolor sit amet, cum alienum splendide te, has ad possim equidem, ad novum insolens usu. An his nonumy tritani scripserit, essent nostro sadipscing mea te, indoctum referrentur mea eu. Te unum urbanitas usu, et sed partem postea neglegentur. Pri dicunt sensibus ex, est prodesset efficiendi id, senserit eloquentiam sit ex.  Ius ea patrioque pertinacia moderatius. Ius errem aliquam splendide te, ne qui exerci diceret mnesarchum. Erant ludus copiosae ad pri, an illum conclusionemque vim. Mel alia consequat in, velit mundi saperet te pro. Tractatos consequuntur id mea.</Panel>
+           <Panel title="Second">Lorem ipsum dolor sit amet, cum alienum splendide te, has ad possim equidem, ad novum insolens usu.</Panel>
+           <Panel title="Third"><Button/></Panel>
+      </Accordion>

--- a/packages/react-atlas-core/src/Accordion/README.md
+++ b/packages/react-atlas-core/src/Accordion/README.md
@@ -37,7 +37,7 @@ Accordion with width set in props as a string:
           <Panel title="Second">Lorem ipsum dolor sit amet, cum alienum splendide te, has ad possim equidem, ad novum insolens usu.</Panel>
      </Accordion>
 
-Accordion with defined panel:
+Accordion with expanded panel:
 
      <Accordion>
           <Panel title="First">Lorem ipsum dolor sit amet, cum alienum splendide te, has ad possim equidem, ad novum insolens usu.</Panel>

--- a/packages/react-atlas-core/src/Avatar/Avatar.js
+++ b/packages/react-atlas-core/src/Avatar/Avatar.js
@@ -85,14 +85,18 @@ Avatar.propTypes = {
    * @examples "SomeName", <SomeIcon />, <img src="/path/to/image.jpg"/>
    */
   "children": PropTypes.node,
-  /** An Object, array, or string of CSS classes to apply to avatar.*/
+  /** CSS classes to apply to Avatar.*/
   "className": PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.object,
     PropTypes.array
   ]),
   /**
-   * For displaying an icon/glphyicon. Normally these will be another component or an element with a class on it.
+   * An URL for an image that is displayed when the main image fails to load.
+   */
+  "defaultImage": PropTypes.string,
+  /**
+   * For displaying an icon/glphyicon. Usually another component or an element with a class on it.
    * @examples <GithubIcon />, <i class="fa fa-github"></i>
    */
   "icon": PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
@@ -102,19 +106,14 @@ Avatar.propTypes = {
    */
   "image": PropTypes.string,
   /**
-   * A string. Avatar will use the first letter of the string.
+   * Pass inline styles here.
+   */
+  "style": PropTypes.object,
+  /**
+   * Avatar will use the first letter of the title string when children, image, and icon are not supplied.
    * @examples "Nathan" will output "N"
    */
-  "title": PropTypes.string,
-  /**
-   * A URL to a image that is displayed when the main image fails to load.
-   */
-  "defaultImage": PropTypes.string,
-
-  /**
-   * Prop to pass inline styles.
-   */
-  "style": PropTypes.object
+  "title": PropTypes.string
 };
 
 export default Avatar;

--- a/packages/react-atlas-core/src/Avatar/Avatar.js
+++ b/packages/react-atlas-core/src/Avatar/Avatar.js
@@ -92,7 +92,7 @@ Avatar.propTypes = {
     PropTypes.array
   ]),
   /**
-   * An URL for an image that is displayed when the main image fails to load.
+   * A URL for an image that is displayed when the main image fails to load.
    */
   "defaultImage": PropTypes.string,
   /**

--- a/packages/react-atlas-default-theme/src/Accordion/Accordion.css
+++ b/packages/react-atlas-default-theme/src/Accordion/Accordion.css
@@ -17,7 +17,7 @@
     composes: pad-h-2 from '../styles.css';
 }
 .centerAlign {
-    text-align: right;
+    text-align: center;
 }
 .accordion_header {
     composes: marg-0  from '../styles.css';


### PR DESCRIPTION
- Alphabetized prop lists (this is the way many other frameworks do it to make it easy for users to find props)
- Updated descriptions for clarity and consistency
- Fixed css bug on Accordion center titlePosition
- Added examples where missing