### PR TITLE
updating docs for Hint

### DIFF
--- a/packages/react-atlas-core/src/Hint/Hint.js
+++ b/packages/react-atlas-core/src/Hint/Hint.js
@@ -23,19 +23,19 @@ class Hint extends React.PureComponent {
 }
 
 Hint.propTypes = {
-  /** An Object, array, or string of CSS classes to apply to Hint.*/
+  /**
+   * Text to be displayed can be passed as a child.
+   * @examples '<Hint>This is a text hint</Hint>'
+   */
+  "children": PropTypes.node,
+  /** An object, array, or string of CSS classes to apply to Hint.*/
   "className": PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.object,
     PropTypes.array
   ]),
   /**
-   * Text to be displayed can be passed as a child.
-   * @examples '<Hint>This is a text hint</Hint>'
-   */
-  "children": PropTypes.node,
-  /**
-   * Text to be displayed (will override children if passed).
+   * Text that will be displayed (will override children if passed).
    * @examples '<Hint text="This is a text hint"/>'
    */
   "text": PropTypes.string,

--- a/packages/react-atlas-core/src/Hint/README.md
+++ b/packages/react-atlas-core/src/Hint/README.md
@@ -1,15 +1,13 @@
-Hint component allows to display a little label, mostly rendered alongside imputs.
+###### Default Hint:
+    <div>
+        <TextField small label="Phone Number:"/>
+        <Hint>10 digit number including area code</Hint>
+    </div>
 
-###### Default hint:
-
-    <Hint>This is a hint text</Hint>
-
-###### Passing text as prop (this will override children):
-
-	<Hint text="This is a hint text" />
-
-###### Hint with custom css classes:
-
-	<Hint className="custom hint-new">This is a hint text</Hint>
+###### Passing text as prop:
+    <div>
+        <TextField small label="CVV Code:"/>
+	    <Hint text="The 3 or 4 digit number on the back of your card" />
+    </div>
 
 


### PR DESCRIPTION
- alphabetized props in docs for Hint
- updated props descriptions for Hint
- updated examples for Hint, included TextFields in the examples to show better context for how Hint is intended to be used
- removed the example for className, since we don't do that example on other components and also since it's really hard to demonstrate since we don't have the css so the user can actually see a change.  If we want to do examples for this, we should think about how best to demonstrate it.