### PR TITLE
cleaning up docs for Form

### DIFF
--- a/packages/react-atlas-core/src/Form/Form.js
+++ b/packages/react-atlas-core/src/Form/Form.js
@@ -235,44 +235,59 @@ class Form extends React.PureComponent {
 }
 
 Form.propTypes = {
-  /** Children components, Usually a Textfield, Dropdown, Input, etc */
+  /** The URL of the server that Form will send data to. Data will be passed as a querystring.*/
+  "action": PropTypes.string,
+
+  /** When true, input elements will have their values
+   * automatically completed by the browser. This setting can be overridden
+   * by an autocomplete attribute on an element belonging to the form. */
+  "autocomplete": PropTypes.bool,
+
+  /** The text that will be displayed inside the submit button. */
+  "buttonText": PropTypes.string,
+
+  /** An object, array, or string of CSS classes to
+   * apply to Form's children components.*/
+  "childClasses": PropTypes.node,
+
+  /** Children components, usually a TextField, Dropdown, Checkbox, etc. */
   "children": PropTypes.node,
-  /** An Object, array, or string of CSS classes to apply to Form.*/
+
+  /** An object, array, or string of CSS classes to apply to Form.*/
   "className": PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.object,
     PropTypes.array
   ]),
-  /** A callback that is fired when the form has passed validation
-   * and is ready to submit. Returns the form data and the event object.  */
-  "onSubmit": PropTypes.func,
-  /** A Callback that is called when there is a form error. */
-  "onError": PropTypes.func,
-  /** The URL of the server to send data to. */
-  "action": PropTypes.string,
-  /** The text displayed inside the submit button. */
-  "buttonText": PropTypes.string,
-  /** The HTTP method to use when action is set and
-   * the form is submitting. */
+
+  /** When the value of the method attribute is post, enctype is the
+   *  MIME type of content that will be used to submit Form to the server. */
+  "enctype": PropTypes.string,
+
+  /** The HTTP method that will be used when action is set and
+   * the form is submitting. Default is POST.*/
   "method": PropTypes.string,
-  /** An Object, array, or string of CSS classes to
-   * apply to form children components.*/
-  "childClasses": PropTypes.node,
-  /** Pass inline styling here. **/
-  "style": PropTypes.object,
-  /** Indicates whether input elements can by default have their values automatically completed by the browser. This setting can be overridden by an autocomplete attribute on an element belonging to the form. **/
-  "autocomplete": PropTypes.bool,
-  /** The name of the form.  **/
+
+  /** The name of the Form.  */
   "name": PropTypes.string,
-  /** A name or keyword indicating where to display the response that is received after submitting the form. _self: Load the response into the same HTML 4 frame (or HTML5 browsing context) as the current one. This value is the default if the attribute is not specified.
-_blank: Load the response into a new unnamed HTML 4 window or HTML5 browsing context.
-_parent: Load the response into the HTML 4 frameset parent of the current frame, or HTML5 parent browsing context of the current one. If there is no parent, this option behaves the same way as _self.
-_top: HTML 4: Load the response into the full original window, and cancel all other frames. HTML5: Load the response into the top-level browsing context (i.e., the browsing context that is an ancestor of the current one, and has no parent). If there is no parent, this option behaves the same way as _self.  **/
-  "target": PropTypes.string,
-  /** This Boolean indicates wether to use HTML5 validations or not. **/
+
+  /** When true, Form will not use HTML5 validation. */
   "novalidate": PropTypes.bool,
-  /** When the value of the method attribute is post, enctype is the MIME type of content that is used to submit the form to the server **/
-  "enctype": PropTypes.string
+
+  /** A Callback that will be executed when there is a form error.
+   * _Example: function(errorMsg)_*/
+  "onError": PropTypes.func,
+
+  /** A callback that will be executed when the form has passed validation
+   * and is ready to submit. Returns the form data and the event object.
+   * _Example: function(event, data) {}_*/
+  "onSubmit": PropTypes.func,
+
+  /** Pass inline styling here. */
+  "style": PropTypes.object,
+
+  /** A name or keyword indicating where to display the response that will be received after submitting the form.*/
+  "target": PropTypes.string
 };
 
 Form.defaultProps = {

--- a/packages/react-atlas-core/src/Form/README.md
+++ b/packages/react-atlas-core/src/Form/README.md
@@ -1,16 +1,14 @@
-The Form component is used for sending data to a server. The Form component can be used with any react-atlas input component, for example components like Input, TextArea, TextField, Dropdown, RadioGroup, etc. The Form component does not style child components by default and will ignore inputs without a name prop. There are two main ways of using the Form component and they both deal with how to send form data to the server. First a user can use the action prop to set the URL to send data to. By default POST is used, this can be overidden by the method prop. When using action, Form will send data as a querystring. Below is an example of using action to send data to a server.
+The Form component can be used with any React Atlas input component. The Form component does not style child
+components by default and will ignore inputs without a name prop.
 
-Basic Form:
+Basic Form with action prop:
 
 		<Form action={"/some/random/url"}>
 		  <TextField small placeholder="Text" required type="text" name="textName"></TextField>
 			<Button type="submit">Submit</Button>
 		</Form>
 
-
-However many times a server does not accept querystrings or you want to do some post processing, client side before sending the data back to the server. For this use onSubmit instead of action. onSubmit takes a function with the signature `function(event, data) {}` . Event is the click event on the submit button and data is a object containing data in key value pairs. The keys are the name of the child component and value is the value of the child component. Below is an example of using onSubmit.
-
-onSubmit Form:
+Form with onSubmit prop:
 
 		<Form onSubmit={function(event, data) {console.log("event: ", event); console.log("data: ", data);}}>
 		  <TextField small placeholder="Email" required type="email" name="email"></TextField>
@@ -19,9 +17,7 @@ onSubmit Form:
 			<Button type="submit">Submit</Button>
 		</Form>
 
-But what about errors? good question. To get Form errors use the onError prop. This callback will fire whenever an error has occured. The callback looks like this `function(errorMsg)`. The errorMsg provides a generic error message for this specific error. Below is an example of using onError with onSubmit.
-
-Error Form:
+Form with onError prop:
 
 	<Form onError={function(errorMsg){console.log(errorMsg)}} onSubmit={function(event, data) {console.log("event: ", event); console.log("data: ", data);}}>
 	  <TextField small placeholder="Email" required type="email" name="email"></TextField>


### PR DESCRIPTION
- alphabetized props
- updated props descriptions
- for consistency, moved relevant info from example descriptions into props descriptions so that it was more similar to other components.  at some point, we may go back and write brief paragraphs for all component examples.