### PR TITLE
Modal documentation and css fixes

### DIFF
--- a/packages/react-atlas-core/src/Modal/Modal.js
+++ b/packages/react-atlas-core/src/Modal/Modal.js
@@ -83,44 +83,51 @@ class Modal extends React.PureComponent {
 
 Modal.propTypes = {
   /**
-   * Modal's title
+   * When true, Modal will be visible.
    */
-  "title": PropTypes.string,
-  /** An Object, array, or string of CSS classes to apply to Modal.*/
+  "active": PropTypes.bool,
+
+  /**
+   * Any HTML element or React Component.
+   */
+  "children": PropTypes.node.isRequired,
+
+  /** An object, array, or string of CSS classes to apply to Modal.*/
   "className": PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.object,
     PropTypes.array
   ]),
+
   /**
-   * Anything that can be in a modal.
-   */
-  "children": PropTypes.node.isRequired,
-  /**
-   * Determines show Modal or not
-   */
-  "active": PropTypes.bool,
-  /**
-   * Event handler for esc key down, normally use to close modal if needed.
-   */
-  "onEscKeyDown": PropTypes.func,
-  /**
-   * Determines show Modal with overlay or not
-   */
-  "overlay": PropTypes.bool,
-  /**
-   * Event handler for clicking on overlay, normally use to close modal if needed.
-   */
-  "onOverlayClick": PropTypes.func,
-  /**
-   * Determines to hide page scroll
+   * When true, Modal will hide page scroll.
    */
   "lockScroll": PropTypes.bool,
 
   /**
+   * Event handler for esc key down, can be used to close Modal if needed.
+   */
+  "onEscKeyDown": PropTypes.func,
+
+  /**
+   * Event handler for clicking on overlay, can be used to close Modal if needed.
+   */
+  "onOverlayClick": PropTypes.func,
+
+  /**
+   * When true, Modal will display with overlay.
+   */
+  "overlay": PropTypes.bool,
+
+  /**
    * Pass inline styling here.
    */
-  "style": PropTypes.object
+  "style": PropTypes.object,
+
+  /**
+   * Title that will be displayed in Modal.
+   */
+  "title": PropTypes.string
 };
 
 Modal.defaultProps = {

--- a/packages/react-atlas-core/src/Modal/README.md
+++ b/packages/react-atlas-core/src/Modal/README.md
@@ -13,8 +13,7 @@ Basic Modal:
             onEscKeyDown={handleToggle}
             title="Modal Example Title"
         >
-            <div>This is Modal example<br/>Any child components could be put here.</div>
-            <Switch small/>
-            <Button raised primary onClick={handleToggle} >Close!</Button>
+            <p>This is a basic Modal example. Any child components could be put here.</p>
+            <Button primary onClick={handleToggle} >Close!</Button>
         </Modal>
 	</div>

--- a/packages/react-atlas-default-theme/src/Modal/Modal.css
+++ b/packages/react-atlas-default-theme/src/Modal/Modal.css
@@ -13,10 +13,9 @@
 
 .title {
 	margin: 0;
-    color: rgb(75, 96, 126);
+    color: var(--blue);
     font-size: 25px;
     padding-bottom: 20px;
-	font-weight: rgb(6, 181, 234);
 }
 
 .content {
@@ -29,13 +28,11 @@
     right: 0;
     bottom: 0;
     left: 0;
-    height: 100%;
 }
 
 .dialog{
     position:relative;
-    margin:15% auto;
-    margin-bottom:43px;
+    margin:auto;
     z-index:1050;
 }
 


### PR DESCRIPTION
- alphabetized props
- updated props descriptions
- fixed an issue where the dimensions of the .dialogWrapper and .dialog css classes were preventing onOverlayClick events from triggering when the user's mouse was vertically above or below the modal but still within the horizontal width of the modal.  

We should probably review the CSS on this one sometime - there's some stuff here that looks like it may be specifically for the login project that wouldn't be styleguide consistent when modal is used for other things, and we could probably be using composes and vars in a few places we aren't.