### PR TITLE
updates for Alert based on code review

### DIFF
--- a/packages/react-atlas-core/src/Alert/Alert.js
+++ b/packages/react-atlas-core/src/Alert/Alert.js
@@ -25,23 +25,21 @@ class Alert extends React.PureComponent {
     let { hidden, children, dismissible, type, className, style } = this.props;
     const alertClasses = cx({
       "alert": true,
-      "info": type === "info",
       "success": type === "success",
       "warning": type === "warning",
       "danger": type === "danger"
     });
     return (
-      <div
-        hidden={hidden}
-        className={cx(className)}
-        style={style}>
+      <React.Fragment>
         {this.state.visible &&
-          <div styleName={alertClasses}>
+          <div
+            hidden={hidden}
+            className={cx(className)}
+            style={style}
+            styleName={alertClasses}>
             {dismissible &&
               <div
-                onClick={() => {
-                  this._closeAlert();
-                }}
+                onClick={this._closeAlert}
                 type="button"
                 styleName="close"
                 data-dismiss="alert"
@@ -53,7 +51,7 @@ class Alert extends React.PureComponent {
             {children}
           </div>
         }
-      </div>
+      </React.Fragment>
     );
   }
 }
@@ -63,24 +61,8 @@ Alert.propTypes = {
    * Any HTML element or React Component.
    */
   "children": PropTypes.node.isRequired,
-  /**
-   * When true, the Alert can be dismissed.
-   */
-  "dismissible": PropTypes.bool,
-  /**
-   * Function that will be executed on dismiss.
-   */
-  "onDismiss": PropTypes.func,
-  /**
-   * Will set the Alert's style.
-   */
-  "type": PropTypes.string,
 
   /**
-   * A boolean to hide or show the alert component.
-   */
-  "hidden": PropTypes.bool,
-  /*
    * An object, array, or string of CSS classes to apply to Button.
    */
   "className": PropTypes.oneOfType([
@@ -88,10 +70,31 @@ Alert.propTypes = {
     PropTypes.object,
     PropTypes.array
   ]),
+
+  /**
+   * When true, the Alert can be dismissed.
+   */
+  "dismissible": PropTypes.bool,
+
+  /**
+   * A boolean to hide or show the alert component.
+   */
+  "hidden": PropTypes.bool,
+
+  /**
+   * Function that will be executed on dismiss.
+   */
+  "onDismiss": PropTypes.func,
+
   /**
    * Pass inline styles here.
    */
-  "style": PropTypes.object
+  "style": PropTypes.object,
+
+  /**
+   * Will set the Alert's style.  One of: 'info', 'success', 'warning', 'danger'
+   */
+  "type": PropTypes.string
 };
 
 Alert.defaultProps = {

--- a/packages/react-atlas-core/src/Alert/README.md
+++ b/packages/react-atlas-core/src/Alert/README.md
@@ -1,6 +1,12 @@
+Alert:
+    <Alert>
+        This is a default Alert!
+    </Alert>
+
 Alert types:
 
-	<div>	
+	<div>
+
 		<Alert type="success">
 	        <strong>Success!</strong> This alert box indicates a successful or positive action.
 	    </Alert>

--- a/packages/react-atlas-default-theme/src/Alert/Alert.css
+++ b/packages/react-atlas-default-theme/src/Alert/Alert.css
@@ -3,19 +3,15 @@
 .alert {
 	composes: default-text from '../styles.css';
   	composes: default-font from '../styles.css';
-    padding: 15px;
-    border: 1px solid #ddd;
-    border-left: 5px solid #ddd;
-    border-radius: 2px;
-    background-color: #fff;
+    composes: primary-gray-border from '../styles.css';
+    composes: rounded from '../styles.css';
+    composes: pad-2 from '../styles.css';
+    composes: bg-body from '../styles.css';
+    border-left: 5px solid var(--info);
 }
 
 .success {
     border-left-color: var(--success);
-}
-
-.info {
-    border-left-color: var(--info);
 }
 
 .warning {
@@ -27,24 +23,19 @@
 }
 
 .close {
+    composes: bold from '../styles.css';
+    composes: bg-transparent from '../styles.css';
+    composes: pad-0 from '../styles.css';
+    composes: cursor-pointer from '../styles.css';
+    composes: border-none from '../styles.css';
 	float: right;
-    font-size: 35px;
-    font-weight: bold;
-    line-height: 0.80;
-    color: #000;
-    text-shadow: 0 1px 0 #fff;
+    font-size: 2.2rem;
     opacity: .2;
     filter: alpha(opacity=20);
-    padding: 0;
-    cursor: pointer;
-    background: transparent;
-    border: 0;
-    -webkit-appearance: none;
     position: relative;
-    top: -6px;
+    top: -10px;
     right: -2px;
-    color: inherit;
-    font-family:inherit;
+    -webkit-appearance:none;
 }
 
 .close:hover {

--- a/packages/react-atlas-tests/Alert/__tests__/__snapshots__/alert.test.js.snap
+++ b/packages/react-atlas-tests/Alert/__tests__/__snapshots__/alert.test.js.snap
@@ -5,14 +5,11 @@ exports[`Test Alert component renders correctly 1`] = `
   className=""
   hidden={undefined}
   style={undefined}
+  styleName="alert success"
 >
-  <div
-    styleName="alert success"
-  >
-    <strong>
-      Success!
-    </strong>
-     This alert box indicates a successful or positive action.
-  </div>
+  <strong>
+    Success!
+  </strong>
+   This alert box indicates a successful or positive action.
 </div>
 `;

--- a/packages/react-atlas-tests/Alert/__tests__/alert.test.js
+++ b/packages/react-atlas-tests/Alert/__tests__/alert.test.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { mount } from "enzyme";
 import { AlertCore } from "../../../react-atlas-core/src/Alert/index";
 import renderer from 'react-test-renderer';
 


### PR DESCRIPTION
- removed unused import from test
- updated css to use compose and vars where possible
- added example for default (no type specified)
- moved .info css rules into main alert rule
- removed extra div wrapper
- updated syntax for onClick call
- alphabetized props
- background & color can now be passed in via style or className
- removed duplicate color in .close css class
- updated prop description for type
- updated snapshot because we removed a div

still to do/investigate:
- did not update propType for type to oneOf because it causes a console warning - seems to be a bug with oneOf
- did not return null if hidden is true.  we are also using state.visible for some things, and this complicates things.  we can investigate this when we work on will receive props for this component.
