### PR TITLE
fixing todos in Button css

### DIFF
--- a/packages/react-atlas-default-theme/src/Button/Button.css
+++ b/packages/react-atlas-default-theme/src/Button/Button.css
@@ -69,42 +69,26 @@
   composes: bg-secondary from '../styles.css';
   composes: hover-bg-secondary from '../styles.css';
   composes: border-secondary from '../styles.css';
-  composes: hover-boder-secondary from '../styles.css';
+  composes: hover-border-secondary from '../styles.css';
   composes: inverse-blue-text from '../styles.css';
 }
 
-/* TODO: Remove hardcoded color values and
- * compose from styles.css */
 .warning {
-  composes: base;
-  color: #FFFFFF;
-  border-color: #F07822;
-  background-color: #F07822;
-}
-
-/* TODO: Remove hardcoded color values and
- * compose from styles.css */
-.warning:hover {
-  color: #FFFFFF;
-  border-color: #E24024;
-  background-color: #E24024;
+  composes: white from '../styles.css';
+  composes: bg-warning from '../styles.css';
+  composes: hover-bg-warning from '../styles.css';
+  composes: border-warning from '../styles.css';
+  composes: hover-border-warning from '../styles.css';
 }
 
 /* TODO: Remove hardcoded color values and
  * compose from styles.css */
 .error {
-  composes: base;
-  color: #FFFFFF;
-  border-color: #EA0F43;
-  background-color: #EA0F43;
-}
-
-/* TODO: Remove hardcoded color values and
- * compose from styles.css */
-.error:hover {
-  color: #FFFFFF;
-  border-color: #BD0A33;
-  background-color: #BD0A33;
+  composes: white from '../styles.css';
+  composes: bg-error from '../styles.css';
+  composes: hover-bg-error from '../styles.css';
+  composes: border-error from '../styles.css';
+  composes: hover-border-error from '../styles.css';
 }
 
 .link {
@@ -162,17 +146,19 @@
 .warning_outline {
   composes: outline;
   composes: orange from '../styles.css';
-  composes: hover-bg-orange from '../styles.css';
+  composes: hover-bg-warning from '../styles.css';
   composes: hover-white from '../styles.css';
-  composes: border-orange from '../styles.css';
+  composes: border-warning from '../styles.css';
+  composes: hover-border-warning from '../styles.css';
 }
 
 .error_outline {
   composes: outline;
   composes: red from '../styles.css';
-  composes: hover-bg-red from '../styles.css';
+  composes: hover-bg-error from '../styles.css';
   composes: hover-white from '../styles.css';
-  composes: border-red from '../styles.css';
+  composes: border-error from '../styles.css';
+  composes: hover-border-error from '../styles.css';
 }
 
 .link_outline {

--- a/packages/react-atlas-default-theme/src/styles/colors.css
+++ b/packages/react-atlas-default-theme/src/styles/colors.css
@@ -80,6 +80,8 @@
 .bg-primary     { background-color: var(--primary) }
 .bg-secondary   { background-color: var(--secondary) }
 .bg-default     { background-color: var(--default) }
+.bg-warning     { background-color: var(--warning) }
+.bg-error       { background-color: var(--error) }
 
 .bg-black    { background-color: var(--black) }
 .bg-gray     { background-color: var(--gray) }
@@ -120,6 +122,8 @@
 .hover-bg-primary:hover     { background-color: var(--primary-darker) }
 .hover-bg-secondary:hover   { background-color: var(--secondary-darker) }
 .hover-bg-default:hover     { background-color: var(--default-lighter) }
+.hover-bg-warning:hover     { background-color: var(--warning-darker) }
+.hover-bg-error:hover       { background-color: var(--error-darker) }
 
 .hover-bg-black:hover  { background-color: var(--black) }
 .hover-bg-gray:hover   { background-color: var(--gray) }
@@ -158,6 +162,8 @@
 .border-primary         { border-color: var(--primary) }
 .border-secondary       { border-color: var(--secondary) }
 .border-default         { border-color: var(--default) }
+.border-warning         { border-color: var(--warning) }
+.border-error         { border-color: var(--error) }
 
 .border-black       { border-color: var(--black) }
 .border-gray        { border-color: var(--gray) }
@@ -196,9 +202,11 @@
 /*Hover-Border Colors */
 .hover-border-transparent:hover  { border-color: transparent }
 
-.hover-border-primary:hover     { border-color: var(--primary-darker) }
-.hover-boder-secondary:hover    { border-color: var(--secondary-darker) }
-.hover-border-default:hover     { border-color: var(--default-lighter) }
+.hover-border-primary:hover         { border-color: var(--primary-darker) }
+.hover-border-secondary:hover       { border-color: var(--secondary-darker) }
+.hover-border-default:hover         { border-color: var(--default-lighter) }
+.hover-border-warning:hover         { border-color: var(--warning-darker) }
+.hover-border-error:hover           { border-color: var(--error-darker) }
 
 .hover-border-black:hover  { border-color: var(--black) }
 .hover-border-gray:hover   { border-color: var(--gray) }

--- a/packages/react-atlas-default-theme/src/styles/variables.css
+++ b/packages/react-atlas-default-theme/src/styles/variables.css
@@ -12,11 +12,13 @@
   --default:                    var(--dark-gray);
   --default-lighter:            var(--primary-gray-lighter);
 
-  --error:      var(--red);
-  --warning:    var(--gold);
-  --success:    var(--primary-green);
-  --info:       var(--primary-blue);
-  --alert:      var(--red);
+  --error:              var(--red);
+  --error-darker:       var(--red-darker);
+  --warning:            var(--orange);
+  --warning-darker:     var(--orange-darker);
+  --success:            var(--primary-green);
+  --info:               var(--primary-blue);
+  --alert:              var(--red);
 
   /* Blue */
   --primary-blue:          var(--sky-blue);
@@ -44,7 +46,9 @@
   /* Warm */
   --yellow:       #FFDC00;
   --orange:       #FF5B00;
+  --orange-darker: #E24024;
   --red:          #DE2525;
+  --red-darker:   #BF2222;
   --fuchsia:      #F012BE;
   --purple:       #B10DC9;
   --gold:         #E1C900;


### PR DESCRIPTION
- there were some Todos in Button.css to remove hardcoded values that I fixed
- added new vars for darker colors for orange, red, warning, error
- added new bg, border, and hover classes for error and warning
- removed unnecessary rules
- updating buttons for warning and error should now be as simple as changing the vars for red, red-darker, orange, orange-darker.