### PR TITLE
Tabs fix

### DIFF
--- a/packages/react-atlas-core/src/TabList/TabList.js
+++ b/packages/react-atlas-core/src/TabList/TabList.js
@@ -50,34 +50,46 @@ class TabList extends React.PureComponent {
 }
 
 TabList.propTypes = {
-  /**
-   * An Object, array, or string of CSS classes to apply to Tabs.
-   */
-  "className": PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.object,
-    PropTypes.array
-  ]),
-  /**
-   * All the tabs.
-   */
-  "children": PropTypes.node.isRequired,
-  /**
-   * Pass inline styling here.
-   */
-  "style": PropTypes.object,
-  /**
-   * Will be automatically set when vertical prop is passed to Tabs component.
-   */
-  "vertical": PropTypes.bool,
-  /**
-   * Selected tab index (default 0 - first tab).
-   */
-  "selectedTab": PropTypes.number,
-  /**
-   * Handler to execute when a tab is selected, in Tabs component.
-   */
-  "setSelectedIndex": PropTypes.func
+    /**
+     * Will be automatically set when bordered prop is passed to Tabs component.
+     *
+     * @ignore
+     */
+    "bordered": PropTypes.bool,
+    /**
+     * An Object, array, or string of CSS classes to apply to Tabs.
+     */
+    "className": PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.object,
+        PropTypes.array
+    ]),
+    /**
+     * All the tabs.
+     */
+    "children": PropTypes.node.isRequired,
+    /** 
+     * Pass inline styling here.
+     */
+    "style": PropTypes.object,
+    /**
+     * Will be automatically set when vertical prop is passed to Tabs component.
+     */
+    "vertical": PropTypes.bool,
+    /**
+     * Selected tab index (default 0 - first tab).
+     */
+    "selectedTab": PropTypes.number,
+    /**
+     * Handler to execute when a tab is selected, in Tabs component.
+     */
+    "setSelectedIndex": PropTypes.func,
+    /**
+     * Indicates whether tab panel is selected or not.
+     *
+     * @ignore
+     */
+    "selected": PropTypes.bool
 };
 
 export default TabList;

--- a/packages/react-atlas-core/src/TabPanel/TabPanel.js
+++ b/packages/react-atlas-core/src/TabPanel/TabPanel.js
@@ -42,34 +42,46 @@ class TabPanel extends React.PureComponent {
 }
 
 TabPanel.propTypes = {
-  /**
-   * An Object, array, or string of CSS classes to apply to Tabs.
-   */
-  "className": PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.object,
-    PropTypes.array
-  ]),
-  /**
-   * Text or other elements (or components) to display as Tab content.
-   */
-  "children": PropTypes.node,
-  /**
-   * Indicates whether tab panel is selected or not.
-   */
-  "selected": PropTypes.bool,
-  /**
-   * Will be automatically set when bordered prop is passed to Tabs component.
-   */
-  "bordered": PropTypes.bool,
-  /**
-   * Will be automatically set when vertical prop is passed to Tabs component.
-   */
-  "vertical": PropTypes.bool,
-  /**
-   * Pass inline styling here.
-   */
-  "style": PropTypes.object
+    /**
+     * An Object, array, or string of CSS classes to apply to Tabs.
+     */
+    "className": PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.object,
+        PropTypes.array
+    ]),
+    /**
+     * Text or other elements (or components) to display as Tab content.
+     */
+    "children": PropTypes.node,
+    /**
+     * Indicates whether tab panel is selected or not.
+     */
+    "selected": PropTypes.bool,
+    /**
+     * Will be automatically set when bordered prop is passed to Tabs component.
+     */
+    "bordered": PropTypes.bool,
+    /**
+     * Will be automatically set when vertical prop is passed to Tabs component.
+     */
+    "vertical": PropTypes.bool,
+    /** 
+     * Pass inline styling here.
+     */
+    "style": PropTypes.object,
+    /**
+     * Selected tab index (default 0 - first tab).
+     *
+     * @ignore
+     */
+    "selectedTab": PropTypes.number,
+    /**
+     * Handler to execute when a tab is selected, in Tabs component.
+     *
+     * @ignore
+     */
+    "setSelectedIndex": PropTypes.func
 };
 
 export default TabPanel;

--- a/packages/react-atlas-core/src/Tabs/Tabs.js
+++ b/packages/react-atlas-core/src/Tabs/Tabs.js
@@ -1,7 +1,6 @@
 import React, { cloneElement } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
-import utils from "../utils/utils";
 
 /**
  * Tabs component

--- a/packages/react-atlas-core/src/Tabs/Tabs.js
+++ b/packages/react-atlas-core/src/Tabs/Tabs.js
@@ -24,27 +24,34 @@ class Tabs extends React.PureComponent {
     }
   };
 
-  render() {
-    const { className, children, vertical, bordered, style } = this.props;
 
-    const tabsChildren = React.Children.map(children, (child, index) => {
-      let childName = utils.getComponentName(child);
+    render() {
+      const {
+          className,
+          children,
+          vertical,
+          bordered,
+          style
+      } = this.props;
 
-      if (childName === "TabList") {
+      const tabsChildren = React.Children.map(children, (child, index) => {
+
         child = cloneElement(child, {
+          // todo
+          // there was once logic here to do these separately based on component name via utils.getComponentName,
+          // but webpack was changing the names so they were all named "t" in prod builds.
+          // This is a workaround for now so that Tabs won't break, but we should come back and
+          // find a better solution later, and probably remove state from some of these at the same time.  stuller 3/13/18
+
+          // needed for TabList so we don't have to send unnecessary props to components
           "selectedTab": this.state.selectedIndex,
           "setSelectedIndex": this._setSelectedIndex,
-          "vertical": vertical
-        });
-      }
-
-      if (childName === "TabPanel") {
-        child = cloneElement(child, {
+          // needed for Tabs
           "selected": this.state.selectedIndex === index - 1,
           "bordered": bordered,
+          // needed for both
           "vertical": vertical
         });
-      }
 
       return child;
     });

--- a/packages/react-atlas-core/src/Tabs/Tabs.js
+++ b/packages/react-atlas-core/src/Tabs/Tabs.js
@@ -41,9 +41,10 @@ class Tabs extends React.PureComponent {
           // there was once logic here to do these separately based on component name via utils.getComponentName,
           // but webpack was changing the names so they were all named "t" in prod builds.
           // This is a workaround for now so that Tabs won't break, but we should come back and
-          // find a better solution later, and probably remove state from some of these at the same time.  stuller 3/13/18
+          // find a better solution later so we don't have to send unnecessary props to components,
+          // and probably remove state from some of these at the same time.  stuller 3/13/18
 
-          // needed for TabList so we don't have to send unnecessary props to components
+          // needed for TabList
           "selectedTab": this.state.selectedIndex,
           "setSelectedIndex": this._setSelectedIndex,
           // needed for Tabs


### PR DESCRIPTION
- temporary fix for Tabs, which were broken in prod build due to utils.getComponentName not working properly because component names get changed during prod build.  We'll put in another issue for that.
- we should refactor these components at some point to get rid of the extra props and eliminate state from TabPanel and TabList