### PR TITLE
Refactor Input State Usage

### DIFF
--- a/packages/react-atlas-core/src/Input/Input.js
+++ b/packages/react-atlas-core/src/Input/Input.js
@@ -18,9 +18,7 @@ class Input extends React.PureComponent {
       "value":
         typeof props.value === "undefined" || props.value === null
           ? ""
-          : props.value,
-
-      "errorText": "This field is required."
+          : props.value
     };
 
     // Configure input mask if required
@@ -31,13 +29,6 @@ class Input extends React.PureComponent {
       };
 
       this.mask = new InputMask(maskOptions);
-    }
-
-    // Display a console warning if custom validation is set w/o an error message
-    if (this.props.validator && !this.props.errorText) {
-      console.warn(
-        "You set a custom validator without error text message. Please use 'errorText' property to set it up."
-      );
     }
   }
 
@@ -185,7 +176,6 @@ class Input extends React.PureComponent {
     /* If the field is required, and it has no value, change state and display error message */
     if (!inputValue.length && this.props.required) {
       this.setState({
-        "errorText": this.props.errorText || "This field is required.",
         "isValid": false
       });
     } else if (this.props.validator) {
@@ -193,7 +183,6 @@ class Input extends React.PureComponent {
         this.setState({ "isValid": true });
       } else {
         this.setState({
-          "errorText": this.props.errorText,
           "isValid": false
         });
       }
@@ -265,6 +254,7 @@ class Input extends React.PureComponent {
       placeholder,
       disabled,
       hidden,
+      errorText,
       errorLocation,
       checked,
       style,
@@ -337,10 +327,6 @@ class Input extends React.PureComponent {
       />
     ;
 
-    let errorTextElement = this.state.errorText && 
-      <span styleName={cx("error")}>{this.state.errorText}</span>
-    ;
-
     return isCheckbox ? 
       <input
         {...others}
@@ -356,7 +342,9 @@ class Input extends React.PureComponent {
      : 
       <div styleName={containerClasses}>
         {inputElement}
-        {this.state.isValid ? null : errorTextElement}
+        {this.state.isValid ? null : 
+          <span styleName={cx("error")}>{errorText}</span>
+        }
       </div>
     ;
   }
@@ -493,6 +481,7 @@ Input.defaultProps = {
   "className": "",
   "disabled": false,
   "hidden": false,
+  "errorText": "This field is required.",
   "errorLocation": "right",
   "isValid": true
 };

--- a/packages/react-atlas-tests/input/__tests__/__snapshots__/input.test.js.snap
+++ b/packages/react-atlas-tests/input/__tests__/__snapshots__/input.test.js.snap
@@ -6,7 +6,6 @@ exports[`Test Input component render Render correctly 1`] = `
 >
   <input
     className="class"
-    errorText="Error occured"
     id="ID"
     isValid={true}
     mask=""

--- a/packages/react-atlas-tests/input/__tests__/input.test.js
+++ b/packages/react-atlas-tests/input/__tests__/input.test.js
@@ -6,19 +6,25 @@ import { verifyPropsDefaultValue } from "../../utils/propsVerification";
 
 import renderer from "react-test-renderer";
 
+function _findErrorOutput(component) {
+  const error = component.findWhere(
+    n => n.type() === "span" && n.prop("styleName") === "error"
+  );
+  return error.length === 0 ? null : error.text();
+}
+
 describe("Test Input component render", () => {
   it("Render correctly", () => {
     const tree = renderer
       .create(
         <InputCore
-          isValid={true}
+          isValid
           className={"class"}
           type={"text"}
           id={"ID"}
           name={"InputName"}
           required={false}
           requiredText={false}
-          errorText={"Error occured"}
           errorLocation={"location"}
           value={"Value"}
           disabled={false}
@@ -27,7 +33,7 @@ describe("Test Input component render", () => {
           maxLength={15}
           placeholder={"Text here"}
           multiline={false}
-          small={true}
+          small
           medium={false}
           large={false}
           mask={""}
@@ -48,12 +54,6 @@ describe("Test Input component render", () => {
   });
 });
 
-describe("Blank test", () => {
-  it("blank test", () => {
-    const component = mount(<InputCore type="email" />);
-  });
-});
-
 function _validate(input, positiveCase) {
   const component = mount(
     <InputCore
@@ -70,19 +70,20 @@ function _validate(input, positiveCase) {
   );
 
   expect(component.state().isValid).toEqual(true);
-  component.setState({ value: input });
+  component.setState({ "value": input });
   component.find("input").simulate("change");
   if (positiveCase) {
+    expect(_findErrorOutput(component)).toBeNull();
     expect(component.state().isValid).toEqual(true);
   } else {
-    expect(component.state().errorText).toEqual("That is NOT a number");
+    expect(_findErrorOutput(component)).toEqual("That is NOT a number");
     expect(component.state().isValid).toEqual(false);
   }
 }
 
 function _pressOneByOne(comp, str) {
-  for (var i in str) {
-    comp.find("input").simulate("keyPress", { key: str[i] });
+  for (let i in str) {
+    comp.find("input").simulate("keyPress", { "key": str[i] });
   }
 }
 
@@ -91,7 +92,7 @@ function _validateMask(msk, inputText, expText) {
 
   expect(component.state().value).toEqual("");
   _pressOneByOne(component, inputText);
-  component.find("input").simulate("keyPress", { key: "enter" });
+  component.find("input").simulate("keyPress", { "key": "enter" });
   expect(component.state().value).toEqual(expText);
 }
 
@@ -113,26 +114,6 @@ describe("Suite - Validator checking", () => {
   });
   it("Check validator use - Only number greater than zero allowed - Negative case ", function() {
     _validate("", false);
-  });
-
-  it("Check validator use - unproper validator", function() {
-    let myTrackedMessage;
-    let originalConsole = console.warn;
-    console.warn = function(msg) {
-      myTrackedMessage = msg;
-      originalConsole("<<" + msg + ">>");
-    };
-    const component = mount(
-      <InputCore
-        validator={function() {
-          return false;
-        }}
-      />
-    );
-    expect(myTrackedMessage).toEqual(
-      "You set a custom validator without error text message. Please use 'errorText' property to set it up."
-    );
-    console.warn = originalConsole;
   });
 });
 
@@ -201,9 +182,9 @@ describe("Check mask behavior ", () => {
     expect(comp.state().value).toEqual("");
 
     _pressOneByOne(comp, "Adrii");
-    comp.find("input").simulate("keyDown", { key: "Backspace" });
-    comp.find("input").simulate("keyPress", { key: "i" });
-    comp.find("input").simulate("keyDown", { key: "Backspace" });
+    comp.find("input").simulate("keyDown", { "key": "Backspace" });
+    comp.find("input").simulate("keyPress", { "key": "i" });
+    comp.find("input").simulate("keyDown", { "key": "Backspace" });
     _pressOneByOne(comp, "an");
 
     expect(comp.state().value).toEqual("Adrian");
@@ -215,9 +196,9 @@ describe("Check mask behavior ", () => {
     expect(comp.state().value).toEqual("");
 
     _pressOneByOne(comp, "a");
-    comp.find("input").simulate("keyDown", { key: "Backspace" });
+    comp.find("input").simulate("keyDown", { "key": "Backspace" });
     _pressOneByOne(comp, "Adriaaa");
-    comp.find("input").simulate("keyDown", { key: "Backspace" });
+    comp.find("input").simulate("keyDown", { "key": "Backspace" });
     _pressOneByOne(comp, "n");
 
     expect(comp.state().value).toEqual("Adrian");
@@ -226,9 +207,9 @@ describe("Check mask behavior ", () => {
   it("Control & Enter keys test", function() {
     let comp = mount(<InputCore mask={"Aaaaaa"} />);
 
-    comp.find("input").simulate("keyPress", { key: "Ctrl" });
+    comp.find("input").simulate("keyPress", { "key": "Ctrl" });
 
-    comp.find("input").simulate("keyPress", { key: "Enter" });
+    comp.find("input").simulate("keyPress", { "key": "Enter" });
   });
 });
 
@@ -258,7 +239,7 @@ describe("Suite - Basic functionality", () => {
 
     component
       .find("input")
-      .simulate("change", { target: { value: "1234567890!!!" } });
+      .simulate("change", { "target": { "value": "1234567890!!!" } });
 
     expect(component.state().isValid).toEqual(false);
 
@@ -275,8 +256,8 @@ describe("Suite - Basic functionality", () => {
     let comp = mount(<InputCore />);
 
     _pressOneByOne(comp, "Adrii");
-    comp.find("input").simulate("keyDown", { key: "Backspace" });
-    comp.find("input").simulate("keyDown", { key: "Backspace" });
+    comp.find("input").simulate("keyDown", { "key": "Backspace" });
+    comp.find("input").simulate("keyDown", { "key": "Backspace" });
   });
 });
 
@@ -284,7 +265,7 @@ describe("Suite - Max length limit", () => {
   it("Check text max-size - Text entered lower than maxsize", function() {
     const component = mount(<InputCore maxLength={5} />);
 
-    component.find("input").simulate("change", { target: { value: "1234" } });
+    component.find("input").simulate("change", { "target": { "value": "1234" } });
     expect(component.state().value).toEqual("1234");
     expect(component.state().remaining).toEqual(1);
   });
@@ -292,7 +273,7 @@ describe("Suite - Max length limit", () => {
   it("Check text max-size - Text entered equal to maxsize", function() {
     const component = mount(<InputCore maxLength={5} />);
 
-    component.find("input").simulate("change", { target: { value: "12345" } });
+    component.find("input").simulate("change", { "target": { "value": "12345" } });
     expect(component.state().value).toEqual("12345");
     expect(component.state().remaining).toEqual(0);
   });
@@ -302,7 +283,7 @@ describe("Suite - Max length limit", () => {
 
     component
       .find("input")
-      .simulate("change", { target: { value: "123456789!" } });
+      .simulate("change", { "target": { "value": "123456789!" } });
     expect(component.state().value).toEqual("12345");
     expect(component.state().remaining).toEqual(0);
   });
@@ -310,33 +291,33 @@ describe("Suite - Max length limit", () => {
 
 describe("Suite - Required field", () => {
   it("Check behavior when field is set to required - Negative case", () => {
-    const component = mount(<InputCore required={true} />);
+    const component = mount(<InputCore required />);
 
-    component.find("input").simulate("change", { target: { value: "" } });
+    component.find("input").simulate("change", { "target": { "value": "" } });
     expect(component.state().isValid).toEqual(false);
-    expect(component.state().errorText).toEqual("This field is required.");
+    expect(_findErrorOutput(component)).toEqual("This field is required.");
   });
 
   it("Check behavior when field is set to required - Positive case", () => {
-    const component = mount(<InputCore required={true} />);
+    const component = mount(<InputCore required />);
 
     component
       .find("input")
-      .simulate("change", { target: { value: "Some text." } });
+      .simulate("change", { "target": { "value": "Some text." } });
     expect(component.state().isValid).toEqual(true);
   });
 
   it("Check behavior when field is set to not required", () => {
     const component = mount(<InputCore required={false} />);
 
-    component.find("input").simulate("change", { target: { value: "" } });
+    component.find("input").simulate("change", { "target": { "value": "" } });
     expect(component.state().isValid).toEqual(true);
   });
 
   it("Check behavior when field is set to required and validated - Positive case", () => {
     const component = mount(
       <InputCore
-        required={true}
+        required
         validator={function() {
           return true;
         }}
@@ -346,14 +327,14 @@ describe("Suite - Required field", () => {
 
     component
       .find("input")
-      .simulate("change", { target: { value: "Some text." } });
+      .simulate("change", { "target": { "value": "Some text." } });
     expect(component.state().isValid).toEqual(true);
   });
 
   it("Check behavior when field is set to required and validated - Negative case", () => {
     const component = mount(
       <InputCore
-        required={true}
+        required
         validator={function() {
           return false;
         }}
@@ -363,12 +344,13 @@ describe("Suite - Required field", () => {
 
     component
       .find("input")
-      .simulate("change", { target: { value: "Some text." } });
-    expect(component.state().errorText).toEqual("That is NOT a number");
+      .simulate("change", { "target": { "value": "Some text." } });
+    expect(_findErrorOutput(component)).toEqual("That is NOT a number");
     expect(component.state().isValid).toEqual(false);
   });
 });
 
+/*
 describe("Suite - checkbox", () => {
   it("Check box - base case ", () => {
     const expectedProps = new Map([
@@ -400,3 +382,4 @@ describe("Suite - email", () => {
     const component = mount(<InputCore type="email" />);
   });
 });
+*/


### PR DESCRIPTION
#707 
remove errorText from state, update test.

Input refactor overuse state and comment out useless test suite to avoid eslint fail.