### PR TITLE
Documentation, css, examples cleanup for O and P components

### DIFF
--- a/packages/react-atlas-core/src/Overlay/Overlay.js
+++ b/packages/react-atlas-core/src/Overlay/Overlay.js
@@ -53,28 +53,32 @@ class Overlay extends React.PureComponent {
 }
 
 Overlay.propTypes = {
-  /** An Object, array, or string of CSS classes to apply to Overlay.*/
+  /**
+   * When true, Overlay will display
+   */
+  "active": PropTypes.bool,
+
+  /** An object, array, or string of CSS classes to apply to Overlay.*/
   "className": PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.object,
     PropTypes.array
   ]),
-  /**
-   * Determines show overlay or not
-   */
-  "active": PropTypes.bool,
-  /**
-   * Click event handler.
-   */
-  "onClick": PropTypes.func,
+
   /**
    * Determines to hide page scroll
    */
   "lockScroll": PropTypes.bool,
+
   /**
    * Event handler for esc key down
    */
   "onEscKeyDown": PropTypes.func,
+
+  /**
+   * Click event handler.
+   */
+  "onClick": PropTypes.func,
 
   /**
    * Pass inline styling here.

--- a/packages/react-atlas-core/src/Panel/Panel.js
+++ b/packages/react-atlas-core/src/Panel/Panel.js
@@ -7,9 +7,12 @@ class Panel extends React.PureComponent {
     super(props);
   }
   render() {
+    const panelStyles = cx({
+      "panel": true
+    });
     const { className, children, style } = this.props;
     return (
-      <div style={style} className={cx(className)}>
+      <div style={style} className={cx(className)} styleName={panelStyles}>
         {children}
       </div>
     );
@@ -17,17 +20,17 @@ class Panel extends React.PureComponent {
 }
 
 Panel.propTypes = {
-  /** An Object, array, or string of CSS classes to apply to Panel.*/
+  /**
+   * Text, any HTML element, or React Component.
+   */
+  "children": PropTypes.node,
+
+  /** An object, array, or string of CSS classes to apply to Panel.*/
   "className": PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.object,
     PropTypes.array
   ]),
-  /**
-   * Text to be displayed can be passed as a child.
-   * @examples '<Panel>This is a text hint</Panel>'
-   */
-  "children": PropTypes.node,
 
   /**
    * Pass inline styling here.

--- a/packages/react-atlas-core/src/Portal/Portal.js
+++ b/packages/react-atlas-core/src/Portal/Portal.js
@@ -72,8 +72,12 @@ class Portal extends Component {
 }
 
 Portal.propTypes = {
+  /**
+   * Text, any HTML element, or React Component.
+   */
   "children": PropTypes.node,
-  /** An Object, array, or string of CSS classes to apply to Portal.*/
+
+  /** An object, array, or string of CSS classes to apply to Portal.*/
   "className": PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.object,

--- a/packages/react-atlas-core/src/ProgressBar/ProgressBar.js
+++ b/packages/react-atlas-core/src/ProgressBar/ProgressBar.js
@@ -128,49 +128,61 @@ ProgressBar.propTypes = {
    * @examples ''
    */
   "buffer": PropTypes.number,
-  /** An Object, array, or string of CSS classes to apply to ProgressBar.*/
+
+  /** An object, array, or string of CSS classes to apply to ProgressBar.*/
   "className": PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.object,
     PropTypes.array
   ]),
+
   /**
-   * Sets color for the upfront color.
+   * Determines what color the ProgressBar will be.
    * @examples '<ProgressBar color="red"/>'
    */
   "color": PropTypes.string,
+
+  /**
+   * The max value of the ProgressBar
+   */
+  "max": PropTypes.number,
+
+  /**
+   * The min value of the ProgressBar
+   */
+  "min": PropTypes.number,
+
+  /**
+   * Mode can be one of: 'determinate', 'indeterminate'
+   * indeterminate will show a cycling ProgressBar; determinate will show progress based on value.
+   */
+  "mode": PropTypes.string,
+
+  /**
+   * If true, ProgressBar will change colors during transition
+   *
+   * @ignore
+   */
+  "multicolor": PropTypes.bool,
+
+  /**
+   * Pass inline styling here.
+   */
+  "style": PropTypes.object,
+
   /**
    * Length of time in seconds for the transition (can use decimals)
    * @examples '35'
    */
   "transitionDuration": PropTypes.string,
+
   /**
-   * The max value of the progress bar
-   * @examples ''
-   */
-  "max": PropTypes.number,
-  /**
-   * The min value of the progress bar
-   * @examples ''
-   */
-  "min": PropTypes.number,
-  /**
-   * Defines the type of Progress bar: 'determinate', 'indeterminate'
-   * @examples 'circular'
-   */
-  "mode": PropTypes.string,
-  /**
-   * If true, progressbar will change colors during transition
-   * @examples ''
-   */
-  "multicolor": PropTypes.bool,
-  /**
-   * Type of progress bar; 'circular' or 'linear'
-   * @examples ''
+   * Type of ProgressBar; 'circular' or 'linear'
    */
   "type": PropTypes.oneOf(["linear", "circular"]),
+
   /**
-   * The default value(s) of the progress bar.  Can be a number, or an object containing keys of "from" and "to"
+   * The default value(s) of the progress bar.  Can be a number or an object containing keys of "from" and "to"
    * @examples '{"from": 10, "to": 80" }'
    */
   "value": PropTypes.oneOfType([
@@ -179,12 +191,7 @@ ProgressBar.propTypes = {
       "from": PropTypes.number,
       "to": PropTypes.number
     })
-  ]),
-
-  /**
-   * Pass inline styling here.
-   */
-  "style": PropTypes.object
+  ])
 };
 
 ProgressBar.defaultProps = {

--- a/packages/react-atlas-core/src/ProgressBar/README.md
+++ b/packages/react-atlas-core/src/ProgressBar/README.md
@@ -1,19 +1,24 @@
-Basic Progress Bar:
+Basic ProgressBar:
 
 	<ProgressBar/>
 
-Basic Progress Bar with custom color:
+Basic ProgressBar with custom color:
 
     <ProgressBar color="red"/>
 
-Determinate Progress Bar:
+Determinate ProgressBar:
 
     <ProgressBar mode="determinate" value="60"/>
 
-Circular Progress Bar:
+ProgressBar with buffer:
+
+    <ProgressBar mode="determinate" value="60" buffer="80"/>
+
+Circular ProgressBar:
 
     <ProgressBar type="circular"/>
 
-Circular determinate Progress Bar with custom color:
+Circular determinate ProgressBar with custom color:
 
     <ProgressBar type="circular" mode="determinate" value="60" color="#4da547"/>
+

--- a/packages/react-atlas-core/src/ProgressBar/README.md
+++ b/packages/react-atlas-core/src/ProgressBar/README.md
@@ -8,11 +8,11 @@ Basic ProgressBar with custom color:
 
 Determinate ProgressBar:
 
-    <ProgressBar mode="determinate" value="60"/>
+    <ProgressBar mode="determinate" value={60}/>
 
 ProgressBar with buffer:
 
-    <ProgressBar mode="determinate" value="60" buffer="80"/>
+    <ProgressBar mode="determinate" value={60} buffer={80}/>
 
 Circular ProgressBar:
 
@@ -20,5 +20,5 @@ Circular ProgressBar:
 
 Circular determinate ProgressBar with custom color:
 
-    <ProgressBar type="circular" mode="determinate" value="60" color="#4da547"/>
+    <ProgressBar type="circular" mode="determinate" value={60} color="#4da547"/>
 

--- a/packages/react-atlas-default-theme/src/Panel/Panel.css
+++ b/packages/react-atlas-default-theme/src/Panel/Panel.css
@@ -1,0 +1,3 @@
+.panel {
+    composes: default-font from '../styles.css';
+}

--- a/packages/react-atlas-default-theme/src/ProgressBar/ProgressBar.css
+++ b/packages/react-atlas-default-theme/src/ProgressBar/ProgressBar.css
@@ -1,8 +1,10 @@
+@import '../styles/variables.css';
+
 .linear {
   position: relative;
   overflow: hidden;
   width: 100%;
-  background: #eee none repeat scroll 0% 0%;
+  background: var(--silver) none repeat scroll 0% 0%;
   height: .4rem;
 }
 .linear.indeterminate .value {
@@ -26,14 +28,11 @@
 }
 
 .value {
-  background-color: rgb(0, 126, 181);
-}
-.disabled {
-    background-color: rgb(179, 179, 179);
+  composes: bg-primary from "../styles.css"
 }
 .buffer {
   background-image: linear-gradient(to right, rgba(255,255,255, 0.7), rgba(255,255,255, 0.7)),
-    linear-gradient(to right, rgb(0, 126, 181), rgb(0, 126, 181));
+    linear-gradient(to right, var(--primary), var(--primary));
 
 }
 
@@ -70,7 +69,7 @@
   stroke-linecap: round;
   stroke-miterlimit: 20;
   stroke-width: 4;
-  stroke: rgb(0, 126, 181);
+  stroke: var(--primary);
 }
 
 .indeterminate {

--- a/packages/react-atlas-tests/panel/__tests__/__snapshots__/panel.test.js.snap
+++ b/packages/react-atlas-tests/panel/__tests__/__snapshots__/panel.test.js.snap
@@ -4,6 +4,7 @@ exports[`Test correct render Test correct render 1`] = `
 <div
   className=""
   style={undefined}
+  styleName="panel"
 >
   Panel Text
 </div>


### PR DESCRIPTION
- updated propType descriptions and alphabetized
- added default font to Panel
- updated ProgressBar examples to include buffer example and to use numbers instead of strings for value prop
- updated CSS to use vars and composes where possible