### PR TITLE
Updating Radio and RadioGroup per code review.

### DIFF
--- a/packages/react-atlas-core/src/Radio/README.md
+++ b/packages/react-atlas-core/src/Radio/README.md
@@ -1,20 +1,15 @@
+The Radio component is a controlled component that must be used within the RadioGroup component. For more examples view the RadioGroup examples.
+
 ###### Default radio:
 
-    <RadioGroup name="test">
+    <RadioGroup name="radioTest">
 		<Radio label="Option 1" value="first"/>
 		<Radio label="Option 2" value="second"/>
 	</RadioGroup>
 
-###### Check radio by default:
-
-    <RadioGroup name="test">
-		<Radio label="Option 1" value="first"/>
-		<Radio label="Option 2" value="second" defaultChecked/>
-	</RadioGroup>
-
 ###### Disabled radio:
 
-    <RadioGroup name="test">
+    <RadioGroup name="disabledTest">
 		<Radio label="Option 1" value="first"/>
 		<Radio label="Option 2" value="second" disabled/>
 		<Radio label="Option 3" value="third"/>
@@ -22,7 +17,7 @@
 
 ###### Hidden radio:
 
-    <RadioGroup name="test">
+    <RadioGroup name="hiddenTest">
 		<Radio label="Option 1" value="first"/>
 		<Radio label="Option 2" value="second" hidden/>
 		<Radio label="Option 3" value="third"/>
@@ -30,24 +25,31 @@
 
 ###### Radio with left-positioned label:
 
-    <RadioGroup name="test">
+    <RadioGroup name="leftLabelTest">
 		<Radio label="Option 1" labelPosition="left" value="first"/>
 		<Radio label="Option 2" value="second"/>
 	</RadioGroup>
 
 ###### Custom onClick method:
 
-    <RadioGroup name="test">
-		<Radio label="Custom onClick" value="first" onClick={ () => { alert('clicked!') } }/>
+    <RadioGroup name="onClickTest">
+		<Radio label="Custom onClick" value="first" onClick={ (data) => { console.log(data.index, data.value) } }/>
+		<Radio label="Normal Radio" value="second"/>
+	</RadioGroup>
+
+###### Custom onChange method:
+
+    <RadioGroup name="onChangeTest">
+		<Radio label="Custom onChange" value="first" onChange={ (data) => { console.log(data.checked, data.value) } }/>
 		<Radio label="Normal Radio" value="second"/>
 	</RadioGroup>
 
 ###### Custom function before change:
 
-    <RadioGroup name="test">
+    <RadioGroup name="onBeforeChangeTest">
 		<Radio 
 			label="Custom onBeforeChange"
 			value="first" 
-			onBeforeChange={ function(value){ if (!value) { let accept = confirm("Do you want to check this?"); return accept; } return true; } }/>
+			onBeforeChange={ function(data){ if (!data.checked) { let accept = confirm("Do you want to check this?"); return accept; } return true; } }/>
 		<Radio label="Normal Radio" value="second"/>
 	</RadioGroup>

--- a/packages/react-atlas-core/src/Radio/Radio.js
+++ b/packages/react-atlas-core/src/Radio/Radio.js
@@ -1,128 +1,107 @@
 import React from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
-import { InputCore } from "../Input";
 
 class Radio extends React.PureComponent {
   constructor(props) {
     super(props);
+  }
 
-    /* Classes and styles setup */
-    let inlineRadio = cx(
-      {
-        "inline_block": this.props.inline,
-        "hidden": this.props.hidden
-      },
-      "radio_padding"
-    );
-
-    let labelStyle = cx({
-      "label": this.props.labelPosition !== "left",
-      "label_left": this.props.labelPosition === "left"
-    });
-
-    let radioDisplay =
-      this.props.labelPosition === "left" ? "float_right" : "float_left";
-
-    let labelTitle = this.props.title ? this.props.title : this.props.label;
-
-    this.classes = {
-      inlineRadio,
-      labelStyle,
-      labelTitle,
-      radioDisplay
-    };
+  componentWillReceiveProps(nextProps) {
+    /* Since Radio is controlled, the only changes that can occur need to come from property updates */
+    if (this.props.onChange && nextProps.checked !== this.props.checked) {
+      this.props.onChange({
+        "checked": nextProps.checked,
+        "value": this.props.value
+      });
+    }
   }
 
   // Handles new radio clicks and sets value and checked status of hidden input
-  _clickHandler = event => {
-    if (!this.props.disabled) {
-      /* Check if onClick has been passed, if so call it. */
-      if (this.props.onClick) {
-        /* Pass the event object, and a data object to the click handler.
-         The data object contains a boolean for whether the radio was
-         clicked or not, plus all the props passed to the object.  */
-        this.props.onClick(event, {
-          "checked": this.props.checked,
-          "props": this.props
-        });
-      }
-
-      this._handleChange();
-
-      /* Check if onChange has been passed, if so call it. */
-      if (this.props.onChange) {
-        /* Pass the event object, and a data object to the change handler.
-         The data object contains a boolean for whether the radio was
-         clicked or not, plus all the props passed to the object.  */
-        this.props.onChange(event, {
-          "checked": this.props.checked,
-          "props": this.props
-        });
-      }
+  _clickHandler = () => {
+    if (this.props.disabled) {
+      return false;
     }
-  };
 
-  _handleChange = () => {
+    if (this.props.onClick) {
+      this.props.onClick({ "index": this.props.index, "value": this.props.value });
+    }
+
     if (
       typeof this.props.onBeforeChange === "undefined" ||
-      this.props.onBeforeChange(this.props.checked)
+      this.props.onBeforeChange({
+        "checked": this.props.checked,
+        "value": this.props.value
+      })
     ) {
-      if (!this.props.checked) {
-        this.props.groupSetChecked(this.props.value);
-      }
+      this.props.groupSetChecked(this.props.index);
     }
   };
 
   render() {
     const {
-      className,
-      value,
-      label,
-      name,
       checked,
+      className,
       disabled,
       hidden,
+      id,
+      inline,
+      label,
+      labelPosition,
       style,
+      title,
       ...others
     } = this.props;
 
-    const { inlineRadio, labelStyle, labelTitle, radioDisplay } = this.classes;
+    /* Classes and styles setup */
+    let wrapperStyles = cx(
+      {
+        "inline_block": inline,
+        "hidden": hidden
+      },
+      "radio_padding"
+    );
+
+    let labelStyle = cx(
+      {
+        "label_left": labelPosition === "left"
+      },
+      "label"
+    );
+
+    let radioDisplay = labelPosition === "left" ? "float_right" : "float_left";
+
+    let labelTitle = title || label;
 
     let radioClass = cx({
-      "checked": checked,
-      "not_checked": !checked
+      "radio": true,
+      "checked": checked
     });
 
-    let disabledClass = disabled
-      ? cx("disabled", "inline_block", "relative", "padding")
-      : cx("inline_block", "relative", "padding");
-
     return (
-      <div style={style} onClick={this._clickHandler} styleName={inlineRadio}>
-        <div styleName={disabledClass}>
+      <div style={style} onClick={this._clickHandler} styleName={wrapperStyles}>
+        <div
+          styleName={cx({ disabled }, "inline_block", "relative", "padding")}
+        >
           {label && 
             <label
               styleName={labelStyle}
               title={labelTitle}
               className={cx(className)}
+              htmlFor={id}
             >
               {label}
             </label>
           }
           <div styleName={radioDisplay}>
-            <InputCore
+            <input
               {...others}
-              label={label}
               type="radio"
               checked={checked}
               disabled={disabled}
               hidden={hidden}
-              name={name}
-              value={value}
-              /* Hardcode classes for InputCore because classes on styleName will not
-               * be evaluated because we are using InputCore rather than Input.  */
-              className={"ra_Input__max ra_Input__opacity"}
+              id={id}
+              styleName={cx("input_style")}
             />
             <div styleName={radioClass}>
               {checked && <div styleName={"checkmark"} />}
@@ -135,11 +114,6 @@ class Radio extends React.PureComponent {
 }
 
 Radio.propTypes = {
-  /**
-   * Determines if the radio button is checked by default.
-   * @examples '<Radio defaultChecked/>'
-   */
-  "defaultChecked": PropTypes.bool,
   /** An Object, array, or string of CSS classes to apply to Radio.*/
   "className": PropTypes.oneOfType([
     PropTypes.string,
@@ -166,6 +140,10 @@ Radio.propTypes = {
    * @examples '<Radio hidden/>'
    */
   "hidden": PropTypes.bool,
+  /** Will set the html "id" property on the Radio. */
+  "id": PropTypes.string,
+  /** Represents the index of the Radio within the parent RadioGroup. */
+  "index": PropTypes.number,
   /**
    * Determines if the radio button is displayed as an inline element.
    * @examples '<Radio inline/>'

--- a/packages/react-atlas-core/src/RadioGroup/README.md
+++ b/packages/react-atlas-core/src/RadioGroup/README.md
@@ -1,26 +1,40 @@
-Radio Group
+RadioGroup:
 
-    <RadioGroup inline name="test" title="Radio Group">
+    <RadioGroup inline name="radioGroupTest" title="Radio Group">
 		<Radio label="Option 1" value="first"/>
 		<Radio label="Option 2" value="second"/>
 	</RadioGroup>
 
-Inline Radio Group
+RadioGroup with selected Radio:
+
+    <RadioGroup inline name="selectedRadioGroupTest" title="Radio Group" selectedIndex={1}>
+		<Radio label="Option 1" value="first"/>
+		<Radio label="Option 2" value="second"/>
+	</RadioGroup>
+
+Inline RadioGroup:
 
 	<div>    
-	    <RadioGroup title="Radio Group One" inline name="test">
+	    <RadioGroup title="Radio Group One" inline name="inlineRadioGroupTest">
 			<Radio label="Option 1" value="first"/>
 			<Radio label="Option 2" value="second"/>
 		</RadioGroup>
-		<RadioGroup title="Radio Group Two" inline name="test2">
+		<RadioGroup title="Radio Group Two" inline name="inlineRadioGroupTest2">
 			<Radio label="Option 1" value="first"/>
 			<Radio label="Option 2" value="second"/>
 		</RadioGroup>
 	</div>
 
-Radio Group with Inline Children
+RadioGroup with inline children:
 
-    <RadioGroup title="Radio Group" inlineChildren name="test">
+    <RadioGroup title="Radio Group" inlineChildren name="inlineChildrenRadioGroupTest">
+		<Radio label="Option 1" value="first"/>
+		<Radio label="Option 2" value="second"/>
+	</RadioGroup>
+
+RadioGroup with custom onChange event:
+
+    <RadioGroup inline name="onChangeradioGroupTest" title="Radio Group" onChange={ (index) => { console.log(index) } }>
 		<Radio label="Option 1" value="first"/>
 		<Radio label="Option 2" value="second"/>
 	</RadioGroup>

--- a/packages/react-atlas-core/src/RadioGroup/RadioGroup.js
+++ b/packages/react-atlas-core/src/RadioGroup/RadioGroup.js
@@ -7,29 +7,23 @@ class RadioGroup extends React.PureComponent {
     super(props);
     // Initial state
     this.state = {
-      "checkedRadio": this.props.selectedValue
+      "checkedRadio": this.props.selectedIndex || 0
     };
   }
 
-  componentWillMount() {
-    React.Children.map(this.props.children, (child, index) => {
-      if (
-        child.props.defaultChecked ||
-        !this.state.checkedRadio && index === 0
-      ) {
-        this.setState({ "checkedRadio": child.props.value });
-      }
-    });
-  }
-
   componentWillReceiveProps(nextProps) {
-    if (nextProps.selectedValue) {
-      this.setState({ "checkedRadio": nextProps.selectedValue });
+    if (nextProps.selectedIndex) {
+      this.setState({ "checkedRadio": nextProps.selectedIndex });
     }
   }
 
-  groupSetChecked = value => {
-    this.setState({ "checkedRadio": value });
+  groupSetChecked = index => {
+    if (index !== this.state.checkedRadio) {
+      if (this.props.onChange) {
+        this.props.onChange(index);
+      }
+      this.setState({ "checkedRadio": index });
+    }
   };
 
   render() {
@@ -48,12 +42,13 @@ class RadioGroup extends React.PureComponent {
       "inline": inline
     });
 
-    const radioButtons = React.Children.map(children, child => {
+    const radioButtons = React.Children.map(children, (child, index) => {
       child = cloneElement(child, {
         "inline": inlineChildren,
         "name": name,
         "groupSetChecked": this.groupSetChecked,
-        "checked": this.state.checkedRadio === child.props.value
+        "checked": this.state.checkedRadio === index,
+        "index": index
       });
       return child;
     });
@@ -103,6 +98,11 @@ RadioGroup.propTypes = {
    * @examples '<RadioGroup inlineChildren></RadioGroup>'
    */
   "inlineChildren": PropTypes.bool,
+  /**
+   * Sets a handler function to be executed when the selected value of the RadioGroup changes.
+   * @examples '<RadioGroup onChange={onChangeHandler}>'
+   */
+  "onChange": PropTypes.func,
 
   /**
    * Pass inline styling here.
@@ -111,11 +111,11 @@ RadioGroup.propTypes = {
   /**
    * Programatically set the selected/checked Radio component in the RadioGroup.
    */
-  "selectedValue": PropTypes.string
+  "selectedIndex": PropTypes.number
 };
 
 RadioGroup.defaultProps = {
-  "selectedValue": null
+  "selectedIndex": null
 };
 
 export default RadioGroup;

--- a/packages/react-atlas-default-theme/src/Input/Input.css
+++ b/packages/react-atlas-default-theme/src/Input/Input.css
@@ -2,11 +2,6 @@
 	clear: both;
 	display: table;
 }
-input.opacity[type="checkbox"], input.opacity[type="radio"] {
-	/*used by Radio and Checkbox modules, even though not used in Input itself */
-	/*this needs to stay here to avoid display issues with those modules in IE*/
-	opacity: 0;
-}
 .input {
 	composes: pad-1 from '../styles.css';
 	composes: default-border from '../styles.css';

--- a/packages/react-atlas-default-theme/src/Radio/Radio.css
+++ b/packages/react-atlas-default-theme/src/Radio/Radio.css
@@ -25,6 +25,10 @@
 	composes: silver-to-white-gradient from '../styles.css';
 	composes: default-border from '../styles.css';
 	composes: circle from '../styles.css';
+  background: -webkit-linear-gradient(#fff, #e6e6e6); /* For Safari 5.1 to 6.0 */
+  background: -o-linear-gradient(#fff, #e6e6e6); /* For Opera 11.1 to 12.0 */
+  background: -moz-linear-gradient(#fff, #e6e6e6); /* For Firefox 3.6 to 15 */
+  background: linear-gradient(#fff, #e6e6e6); /* Standard syntax */
 }
 
 .disabled {
@@ -55,14 +59,6 @@
 
 .error {
   border: solid 1px #BD0A33;
-}
-
-.not_checked {
-  composes: radio;
-  background: -webkit-linear-gradient(#fff, #e6e6e6); /* For Safari 5.1 to 6.0 */
-  background: -o-linear-gradient(#fff, #e6e6e6); /* For Opera 11.1 to 12.0 */
-  background: -moz-linear-gradient(#fff, #e6e6e6); /* For Firefox 3.6 to 15 */
-  background: linear-gradient(#fff, #e6e6e6); /* Standard syntax */
 }
 
 .label {
@@ -96,4 +92,10 @@
   float:right;
   padding-left: 3px;
   position: relative;
+}
+
+
+.input_style {
+  opacity: 0; /*this needs to stay here to avoid display issues in IE*/
+  width: 100%;
 }

--- a/packages/react-atlas-tests/radio/__tests__/__snapshots__/radio.test.js.snap
+++ b/packages/react-atlas-tests/radio/__tests__/__snapshots__/radio.test.js.snap
@@ -11,6 +11,7 @@ exports[`Test Radio component render Render correctly 1`] = `
   >
     <label
       className="class"
+      htmlFor={undefined}
       styleName="label"
       title="TITLE"
     >
@@ -19,30 +20,19 @@ exports[`Test Radio component render Render correctly 1`] = `
     <div
       styleName="float_left"
     >
+      <input
+        checked={undefined}
+        defaultChecked={true}
+        disabled={false}
+        hidden={false}
+        id={undefined}
+        name="Mr radio"
+        styleName="input_style"
+        type="radio"
+        value="checkedRadio"
+      />
       <div
-        styleName="container"
-      >
-        <input
-          checked={undefined}
-          className="ra_Input__max ra_Input__opacity"
-          defaultChecked={true}
-          inline={true}
-          label="Checked Radio"
-          name="Mr radio"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onPaste={[Function]}
-          styleName=""
-          title="TITLE"
-          type="radio"
-          value="checkedRadio"
-        />
-      </div>
-      <div
-        styleName="not_checked"
+        styleName="radio"
       />
     </div>
   </div>

--- a/packages/react-atlas-tests/radioGroup/__tests__/__snapshots__/radioGroup.test.js.snap
+++ b/packages/react-atlas-tests/radioGroup/__tests__/__snapshots__/radioGroup.test.js.snap
@@ -16,6 +16,7 @@ exports[`Test RadioGroup component render Render correctly 1`] = `
     >
       <label
         className=""
+        htmlFor={undefined}
         styleName="label"
         title="Option 1"
       >
@@ -24,29 +25,20 @@ exports[`Test RadioGroup component render Render correctly 1`] = `
       <div
         styleName="float_left"
       >
+        <input
+          checked={true}
+          disabled={false}
+          groupSetChecked={[Function]}
+          hidden={false}
+          id={undefined}
+          index={0}
+          name="test"
+          styleName="input_style"
+          type="radio"
+          value="first"
+        />
         <div
-          styleName="container"
-        >
-          <input
-            checked={true}
-            className="ra_Input__max ra_Input__opacity"
-            groupSetChecked={[Function]}
-            inline={false}
-            label="Option 1"
-            name="test"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onPaste={[Function]}
-            styleName=""
-            type="radio"
-            value="first"
-          />
-        </div>
-        <div
-          styleName="checked"
+          styleName="radio checked"
         >
           <div
             styleName="checkmark"
@@ -65,6 +57,7 @@ exports[`Test RadioGroup component render Render correctly 1`] = `
     >
       <label
         className=""
+        htmlFor={undefined}
         styleName="label"
         title="Option 2"
       >
@@ -73,29 +66,20 @@ exports[`Test RadioGroup component render Render correctly 1`] = `
       <div
         styleName="float_left"
       >
+        <input
+          checked={false}
+          disabled={false}
+          groupSetChecked={[Function]}
+          hidden={false}
+          id={undefined}
+          index={1}
+          name="test"
+          styleName="input_style"
+          type="radio"
+          value="second"
+        />
         <div
-          styleName="container"
-        >
-          <input
-            checked={false}
-            className="ra_Input__max ra_Input__opacity"
-            groupSetChecked={[Function]}
-            inline={false}
-            label="Option 2"
-            name="test"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onPaste={[Function]}
-            styleName=""
-            type="radio"
-            value="second"
-          />
-        </div>
-        <div
-          styleName="not_checked"
+          styleName="radio"
         />
       </div>
     </div>
@@ -110,6 +94,7 @@ exports[`Test RadioGroup component render Render correctly 1`] = `
     >
       <label
         className=""
+        htmlFor={undefined}
         styleName="label"
         title="Option 3"
       >
@@ -118,29 +103,20 @@ exports[`Test RadioGroup component render Render correctly 1`] = `
       <div
         styleName="float_left"
       >
+        <input
+          checked={false}
+          disabled={false}
+          groupSetChecked={[Function]}
+          hidden={false}
+          id={undefined}
+          index={2}
+          name="test"
+          styleName="input_style"
+          type="radio"
+          value="third"
+        />
         <div
-          styleName="container"
-        >
-          <input
-            checked={false}
-            className="ra_Input__max ra_Input__opacity"
-            groupSetChecked={[Function]}
-            inline={false}
-            label="Option 3"
-            name="test"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onPaste={[Function]}
-            styleName=""
-            type="radio"
-            value="third"
-          />
-        </div>
-        <div
-          styleName="not_checked"
+          styleName="radio"
         />
       </div>
     </div>
@@ -155,6 +131,7 @@ exports[`Test RadioGroup component render Render correctly 1`] = `
     >
       <label
         className=""
+        htmlFor={undefined}
         styleName="label"
         title="Option 4"
       >
@@ -163,29 +140,20 @@ exports[`Test RadioGroup component render Render correctly 1`] = `
       <div
         styleName="float_left"
       >
+        <input
+          checked={false}
+          disabled={false}
+          groupSetChecked={[Function]}
+          hidden={false}
+          id={undefined}
+          index={3}
+          name="test"
+          styleName="input_style"
+          type="radio"
+          value="fourth"
+        />
         <div
-          styleName="container"
-        >
-          <input
-            checked={false}
-            className="ra_Input__max ra_Input__opacity"
-            groupSetChecked={[Function]}
-            inline={false}
-            label="Option 4"
-            name="test"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onPaste={[Function]}
-            styleName=""
-            type="radio"
-            value="fourth"
-          />
-        </div>
-        <div
-          styleName="not_checked"
+          styleName="radio"
         />
       </div>
     </div>
@@ -200,6 +168,7 @@ exports[`Test RadioGroup component render Render correctly 1`] = `
     >
       <label
         className=""
+        htmlFor={undefined}
         styleName="label"
         title="Option 5"
       >
@@ -208,29 +177,20 @@ exports[`Test RadioGroup component render Render correctly 1`] = `
       <div
         styleName="float_left"
       >
+        <input
+          checked={false}
+          disabled={false}
+          groupSetChecked={[Function]}
+          hidden={false}
+          id={undefined}
+          index={4}
+          name="test"
+          styleName="input_style"
+          type="radio"
+          value="fifth"
+        />
         <div
-          styleName="container"
-        >
-          <input
-            checked={false}
-            className="ra_Input__max ra_Input__opacity"
-            groupSetChecked={[Function]}
-            inline={false}
-            label="Option 5"
-            name="test"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onPaste={[Function]}
-            styleName=""
-            type="radio"
-            value="fifth"
-          />
-        </div>
-        <div
-          styleName="not_checked"
+          styleName="radio"
         />
       </div>
     </div>
@@ -245,6 +205,7 @@ exports[`Test RadioGroup component render Render correctly 1`] = `
     >
       <label
         className=""
+        htmlFor={undefined}
         styleName="label"
         title="Option 6"
       >
@@ -253,29 +214,20 @@ exports[`Test RadioGroup component render Render correctly 1`] = `
       <div
         styleName="float_left"
       >
+        <input
+          checked={false}
+          disabled={false}
+          groupSetChecked={[Function]}
+          hidden={false}
+          id={undefined}
+          index={5}
+          name="test"
+          styleName="input_style"
+          type="radio"
+          value="sixth"
+        />
         <div
-          styleName="container"
-        >
-          <input
-            checked={false}
-            className="ra_Input__max ra_Input__opacity"
-            groupSetChecked={[Function]}
-            inline={false}
-            label="Option 6"
-            name="test"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onPaste={[Function]}
-            styleName=""
-            type="radio"
-            value="sixth"
-          />
-        </div>
-        <div
-          styleName="not_checked"
+          styleName="radio"
         />
       </div>
     </div>

--- a/packages/react-atlas-tests/radioGroup/__tests__/radioGroup.test.js
+++ b/packages/react-atlas-tests/radioGroup/__tests__/radioGroup.test.js
@@ -23,14 +23,6 @@ describe("Test RadioGroup component render", () => {
   });
 });
 
-function _findRadio(node, label) {
-  return (
-    node.name() === "input" &&
-    node.props().type === "radio" &&
-    node.props().label === label
-  );
-}
-
 describe("Testing radio component", () => {
   it("RadioGroup - Basic test", function() {
     mount(
@@ -52,13 +44,19 @@ describe("Testing radio component", () => {
         <RadioCore label="Option 6" value="sixth" />
       </RadioGroupCore>
     );
-    expect(result.state().checkedRadio).toEqual("first");
+    expect(result.state().checkedRadio).toEqual(0);
 
-    result.findWhere(n => _findRadio(n, "Option 4")).simulate("click");
-    expect(result.state().checkedRadio).toEqual("fourth");
+    result
+      .find(RadioCore)
+      .last()
+      .simulate("click");
+    expect(result.state().checkedRadio).toEqual(5);
 
-    result.findWhere(n => _findRadio(n, "Option 2")).simulate("click");
-    expect(result.state().checkedRadio).toEqual("second");
+    result
+      .find(RadioCore)
+      .first()
+      .simulate("click");
+    expect(result.state().checkedRadio).toEqual(0);
   });
 
   it("RadioGroup - Change props ", function() {
@@ -74,10 +72,13 @@ describe("Testing radio component", () => {
     );
     result.setProps({ "name": "Name" });
 
-    result.findWhere(n => _findRadio(n, "Option 4")).simulate("click");
-    expect(result.state().checkedRadio).toEqual("fourth");
+    result
+      .find(RadioCore)
+      .last()
+      .simulate("click");
+    expect(result.state().checkedRadio).toEqual(5);
 
-    result.setProps({ "selectedValue": "second" });
-    expect(result.state().checkedRadio).toEqual("second");
+    result.setProps({ "selectedIndex": 1 });
+    expect(result.state().checkedRadio).toEqual(1);
   });
 });


### PR DESCRIPTION
Notes from Code Review ...

- Remove styling from constructor and add to render
- If disabled fail early
- line 72 pass this.props.index instead of this.props.value (see changes to RadioGroup)
- Move onChange into a componentWillReceiveProps since only change can only come from prop update
- Move _handleChange code into _clickHandler, delete _handleChange
- On event callbacks return an object containing this.props.checked and this.props.value
- Remove value and name from render const
- Render not_checked by default, update checked styling when necessary
- Move disabledClass variables to be inline, properly using `cx`
- Rename inlineRadio to wrapperStyles
- Add htmlFor to label
- Add id prop
- Change InputCore to input
- Remove label, name, value from input
- Remove className from input, pull in opacity class from input.js