### PR TITLE
Fix for issues #773 and #767 - FF red borders on required fields, #769 radio styling

### DIFF
--- a/src/Radio/Radio.css
+++ b/src/Radio/Radio.css
@@ -1,101 +1,101 @@
 .disabled {
-  composes: default-text from '../styles.css';
+    composes: default-text from '../styles.css';
 }
 
 .relative {
-  position:relative;
+    position: relative;
 }
 
 .padding {
-  padding-bottom: 5px;
+    padding-bottom: 5px;
 }
 
 .input {
-  composes: relative;
-  top: 1px;
+    composes: relative;
+    top: 1px;
 }
 
 .radio {
-	position: absolute;
-	top: 0px;
-	height: 16px;
-	width: 16px;
-	display: inline-block;
-	composes: cursor-pointer from '../styles.css';
-	composes: silver-to-white-gradient from '../styles.css';
-	composes: default-border from '../styles.css';
-	composes: circle from '../styles.css';
-  background: -webkit-linear-gradient(#fff, #e6e6e6); /* For Safari 5.1 to 6.0 */
-  background: -o-linear-gradient(#fff, #e6e6e6); /* For Opera 11.1 to 12.0 */
-  background: -moz-linear-gradient(#fff, #e6e6e6); /* For Firefox 3.6 to 15 */
-  background: linear-gradient(#fff, #e6e6e6); /* Standard syntax */
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 16px;
+    width: 16px;
+    display: inline-block;
+    composes: cursor-pointer from '../styles.css';
+    composes: silver-to-white-gradient from '../styles.css';
+    composes: default-border from '../styles.css';
+    composes: circle from '../styles.css';
+    background: -webkit-linear-gradient(#fff, #e6e6e6); /* For Safari 5.1 to 6.0 */
+    background: -o-linear-gradient(#fff, #e6e6e6); /* For Opera 11.1 to 12.0 */
+    background: -moz-linear-gradient(#fff, #e6e6e6); /* For Firefox 3.6 to 15 */
+    background: linear-gradient(#fff, #e6e6e6); /* Standard syntax */
 }
 
 .disabled {
-opacity: 0.65;
-composes: cursor-not-allowed from '../styles.css'; 
-pointer-events: none;
+    opacity: 0.65;
+    composes: cursor-not-allowed from '../styles.css';
+    pointer-events: none;
 }
 
 .hidden {
-display: none;
-visibility: hidden;
+    display: none;
+    visibility: hidden;
 }
 
 .checked {
-composes: radio;
-composes: white-inset-shadow from '../styles.css';
-background: #007EB5;
+    composes: radio;
+    composes: white-inset-shadow from '../styles.css';
+    background: #007EB5;
 }
 
 .focus {
-box-shadow: 0 0 6px rgba(35, 173, 255, 1);
+    box-shadow: 0 0 6px rgba(35, 173, 255, 1);
 }
 
 .checkmark {
-composes: relative;
-top: 0px;
+    composes: relative;
+    top: 0px;
 }
 
 .error {
-  border: solid 1px #BD0A33;
+    border: solid 1px #BD0A33;
 }
 
 .label {
-composes: default-font from '../styles.css';
-cursor: pointer;
-white-space: nowrap;
-padding-right:5px;
-margin-left: 12px;
+    composes: default-font from '../styles.css';
+    cursor: pointer;
+    white-space: nowrap;
+    padding-right: 5px;
+    margin-left: 5px;
 }
 
 .label_left {
-composes: label;
-padding-right: 2px;
-margin-left: 0px;
+    composes: label;
+    padding-right: 5px;
+    margin-left: 0;
+    margin-right: 5px;
 }
 
 .inline_block {
-display: inline-block;
+    display: inline-block;
 }
 
 .radio_padding {
-padding: 7px 10px 0 0;
+    padding: 7px 10px 0 0;
 }
 
 .float_left {
-float:left;
-padding-right: 3px;
+    float: left;
+    padding-right: 3px;
 }
 
 .float_right {
-  float:right;
-  padding-left: 3px;
-  position: relative;
+    float: right;
+    padding-left: 3px;
+    position: relative;
 }
 
-
 .input_style {
-  opacity: 0; /*this needs to stay here to avoid display issues in IE*/
-  width: 100%;
+    opacity: 0; /*this needs to stay here to avoid display issues in IE*/
 }

--- a/src/TextArea/TextArea.css
+++ b/src/TextArea/TextArea.css
@@ -3,6 +3,10 @@
 	padding: 5px;
 }
 
+.textarea:-moz-ui-invalid:not(output) {/* fixes red border on required fields in FF */
+	box-shadow: none;
+}
+
 .textareaWidth {
 	width: 100%;
 }

--- a/src/TextArea/TextArea.css
+++ b/src/TextArea/TextArea.css
@@ -3,7 +3,7 @@
 	padding: 5px;
 }
 
-.textarea:-moz-ui-invalid:not(output) {/* fixes red border on required fields in FF */
+.textarea:-moz-ui-invalid {/* fixes red border on required fields in FF */
 	box-shadow: none;
 }
 

--- a/src/TextField/TextField.css
+++ b/src/TextField/TextField.css
@@ -11,6 +11,10 @@
 	outline: none;
 }
 
+.textfield:-moz-ui-invalid { /* fixes red border on required fields in FF */
+	box-shadow: none;
+}
+
 .textfieldWrapper {
 	composes: default-font from '../styles.css';
 	width: 100%;

--- a/src/styles/miscellaneous.css
+++ b/src/styles/miscellaneous.css
@@ -7,25 +7,21 @@
 
 .opacity-0 { opacity: 0;-moz-opacity: 0;-webkit-opacity: 0;-o-opacity: 0; }
 
-.text-input-active { 
-	box-shadow: inset 0 0 4px 1px rgba(0,167,225,.3), 0 0 0 1px rgba(0,167,225,.7);
-	border-color: rgba(0, 167, 225, 0.6);
+.text-input-active {
+	border: 1.6px solid var(--info);
 	outline: none; 
 }
 
-.text-input-invalid { 
-	box-shadow: 0 0 4px #bd0a33;
-	border-color: rgba(189, 10, 51, 0.6); 
+.text-input-invalid {
+	border: 1px solid var(--error);
 }
 
-.text-input-valid { 
-	box-shadow: 0 0 4px var(--success);
-	border-color: rgba(168, 198, 40, 0.6); 
+.text-input-valid {
+	border: 1px solid var(--success);
 }
 
-.text-input-warning { 
-	box-shadow: 0 0 4px var(--warning);
-	border-color: rgba(255, 91, 0, 0.6); 
+.text-input-warning {
+	border: 1px solid var(--warning);
 }
 
 .silver-to-white-gradient {


### PR DESCRIPTION
- Added -moz-ui-invalid rule to fix red borders in FF 
- Removed box shadows from invalid and other input styles because they aren't shown in style guide
- Updated input styles to use vars
- Fixed radio styling issue in IE, FF
- Unified radio/label padding so that it looks the same in all browsers
