### PR TITLE
fix for issue #784: extra border on Accordion header

### DIFF
--- a/src/Accordion/Accordion.css
+++ b/src/Accordion/Accordion.css
@@ -15,7 +15,7 @@
     composes: marg-0  from '../styles.css';
     composes: cursor-pointer from '../styles.css';
     composes: default-border-bottom from '../styles.css';
-    composes: default-border-left from '../styles.css';
+    composes: border-left-none from '../styles.css';
     composes: border-top-none from '../styles.css';
     composes: border-right-none from '../styles.css';
     composes: header-font from '../styles.css';


### PR DESCRIPTION
- changed rule for border left to get rid of the extra 1px border

fix for issue #784 