### PR TITLE
Checkbox Prod Styling

### DIFF
--- a/src/Checkbox/Checkbox.css
+++ b/src/Checkbox/Checkbox.css
@@ -18,7 +18,6 @@
 .checkbox {
   composes: rounded from '../styles.css';
   composes: default-border from "../styles.css";
-  composes: bg-silver from "../styles.css"; /* For browsers that do not support gradients */
   composes: relative;
   position: absolute;
   top: 0px;


### PR DESCRIPTION
Fixes #858. Removes background class originally added for old browser support but that is causing render issues with prod builds.