### PR TITLE
fix for Issue #899 updated fa icons for FA 5.1

### DIFF
--- a/src/Avatar/README.md
+++ b/src/Avatar/README.md
@@ -5,7 +5,7 @@ Title prop gets truncated to 1st letter:
 
 Icon beats title:
 
-    <Avatar title="Nathan" icon="fa fa-github" />
+    <Avatar title="Nathan" icon="fab fa-github" />
 
 Image beats icon:
 
@@ -23,7 +23,7 @@ Child beats parameters:
 
     <div>
       <Avatar title="Nathan" image="https://octodex.github.com/images/codercat.jpg">
-        <i className="fa fa-github"></i>
+        <i className="fab fa-github"></i>
       </Avatar>
 
       <Avatar title="Nathan" icon="fa fa-github">

--- a/src/Breadcrumb/README.md
+++ b/src/Breadcrumb/README.md
@@ -21,7 +21,7 @@ Breadcrumb with icon:
             <Text as="a" href="#">Cat</Text>
         </BreadcrumbItem>
         <BreadcrumbItem>
-            <i className="fa fa-github"></i>
+            <i className="fab fa-github" style={{paddingRight:'5px'}}></i>
             <Text as="a" href="http://www.github.com">GitHub</Text>
         </BreadcrumbItem>
         <BreadcrumbItem active>

--- a/src/Tabs/README.md
+++ b/src/Tabs/README.md
@@ -114,8 +114,8 @@
     <Tabs>
         <TabList>
             <Tab icon="fa fa-star">Tab w/icon</Tab>
-            <Tab icon="fa fa-star-half-empty"/>
-            <Tab icon="fa fa-star-o"/>
+            <Tab icon="far fa-star-half"/>
+            <Tab icon="far fa-star"/>
         </TabList>
         <TabPanel>
             <h2>Tab with icon</h2>


### PR DESCRIPTION
Fixes for Issue #899 

We're using version 5.1 - icon names have changed.  New list is located here: https://fontawesome.com/icons?d=gallery

- updated fa icons in Avatar
- updated fa icons in Tabs
- updated fa icon in Breadcrumb