### PR TITLE
fix for issue #919 - can't set custom width on textField with leftLabel 

### DIFF
--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -8,7 +8,6 @@ import CSSModules from "react-css-modules";
 import styles from "./TextField.css";
 import blacklist from "blacklist";
 
-
 /**
  * TextField's documentation can be found below. Documentation on the mask prop can be found at: https://github.com/insin/inputmask-core
  */
@@ -307,10 +306,12 @@ export class TextField extends React.PureComponent {
       "onBeforeChange"
     );
 
+    const hasCustomWidth = typeof style !== "undefined" && style.width;
+
     let wrapperClasses = cx({
       leftLabel,
       inline,
-      "setWidth": typeof style !== "undefined" && style.width,
+      "setWidth": hasCustomWidth,
       "textfieldWrapper": true
     });
 
@@ -320,7 +321,7 @@ export class TextField extends React.PureComponent {
       "error": this.state.status === "error",
       "success": this.state.status === "success",
       "warning": this.state.status === "warning",
-      "fillInput": leftLabel,
+      "fillInput": leftLabel && !hasCustomWidth,
       disabled
     });
 


### PR DESCRIPTION
Fix for Issue #919
- only apply fillInput style if leftLabel is true and component does not have a style prop with a width