### PR TITLE
Issue #979 - Form hideErrors prop should not be passed down to html form element

### DIFF
--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -254,7 +254,7 @@ export class Form extends React.PureComponent {
   render() {
     const { children, ...others } = this.props;
     // Declaring the following variables so they don't get passed to the Textarea through the prop spread.
-    const othersFiltered = blacklist(others, "onSubmit");
+    const othersFiltered = blacklist(others, "onSubmit", "hideErrors");
     const elements = this._addRefs(children, true);
     const errorList = this.state.errorList.length > 0 &&
       !this.props.hideErrors && 

--- a/src/Form/__tests__/__snapshots__/form.test.js.snap
+++ b/src/Form/__tests__/__snapshots__/form.test.js.snap
@@ -4,7 +4,6 @@ exports[`Test Hint component render Render correctly 1`] = `
 <form
   action="/"
   autoComplete="off"
-  hideErrors={false}
   noValidate={true}
   onSubmit={[Function]}
   validate={true}


### PR DESCRIPTION
Fix for https://github.com/DigitalRiver/react-atlas/issues/979