### PR TITLE
NavItem tests and to prop update

### DIFF
--- a/src/NavItem/NavItem.js
+++ b/src/NavItem/NavItem.js
@@ -32,8 +32,10 @@ export class NavItem extends React.Component {
         disabled={disabled}
         styleName={cx("link", { disabled, subNav })}
         link
-        href={typeof to === "undefined" ? href : null}
-        onClick={typeof to === "undefined" ? this._handleClick : null}
+        href={typeof this.props.to === "undefined" ? href : null}
+        onClick={
+          typeof this.props.to === "undefined" ? this._handleClick : null
+        }
       >
         {children}
         <i styleName={cx({ "caret": parent })} />
@@ -112,7 +114,11 @@ NavItem.propTypes = {
   /** callback for Nav Component
    * @ignore
    */
-  "onClick": PropTypes.func
+  "onClick": PropTypes.func,
+  /** to prop is from the react-router spec
+   * @ignore
+   */
+  "to": PropTypes.string
 };
 
 NavItem.defaultProps = {

--- a/src/NavItem/__tests__/__snapshots__/navItem.test.js.snap
+++ b/src/NavItem/__tests__/__snapshots__/navItem.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test correct render Test correct render 1`] = `
+<li
+  className="navItem"
+  role="presentation"
+  style={undefined}
+>
+  <button
+    className="link button link link_hover"
+    href={undefined}
+    id={undefined}
+    name={undefined}
+    onClick={[Function]}
+    style={undefined}
+    tabIndex={0}
+    type="button"
+  >
+    HOME
+    <i />
+  </button>
+</li>
+`;

--- a/src/NavItem/__tests__/navItem.test.js
+++ b/src/NavItem/__tests__/navItem.test.js
@@ -1,0 +1,119 @@
+import React from "react";
+import { mount } from "enzyme";
+import { Nav } from "../../Nav/index";
+import { NavItem } from "../index";
+import { NavLink, HashRouter } from "react-router-dom";
+
+import renderer from "react-test-renderer";
+
+describe("Test correct render", () => {
+  it("Test correct render", function() {
+    const tree = renderer.create(<NavItem navKey={0}>HOME</NavItem>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});
+
+describe("Testing NavItem component", () => {
+  it("Should render children", function() {
+    const navItem = mount(<NavItem navKey={0}>HOME</NavItem>);
+    expect(navItem.props().children).toBe("HOME");
+    expect(navItem.find("button").text()).toBe("HOME");
+  });
+
+  it("Should require children", function() {
+    console.error = jest.fn();
+    const navItem = mount(<NavItem navKey={0} />); //eslint-disable-line no-unused-vars
+    expect(global.console.error).toBeCalled();
+  });
+
+  it("Should require navKey", function() {
+    console.error = jest.fn();
+    const navItem = mount(<NavItem>HOME</NavItem>); //eslint-disable-line no-unused-vars
+    expect(global.console.error).toBeCalled();
+  });
+
+  it("Should require navKey to be a number", function() {
+    console.error = jest.fn();
+    const navItem = mount(<NavItem navKey="a">HOME</NavItem>); //eslint-disable-line no-unused-vars
+    expect(global.console.error).toBeCalled();
+  });
+
+  it("Should apply classes passed in className", function() {
+    const navItem = mount(
+      <NavItem className="myClass" navKey={0}>
+        HOME
+      </NavItem>
+    );
+    expect(navItem.props().className).toBe("myClass");
+    expect(navItem.find("li").html()).toContain("myClass");
+  });
+
+  it("Should be disabled when disabled prop is true", function() {
+    const navItem = mount(
+      <NavItem disabled navKey={0}>
+        HOME
+      </NavItem>
+    );
+    expect(navItem.find("li").html()).toContain("disabled");
+    expect(navItem.find("li").props().className).toContain("disabled");
+    expect(navItem.find("button").html()).toContain("disabled");
+    expect(navItem.find("button").props().className).toContain("disabled");
+  });
+
+  it("Should pass href", function() {
+    const navItem = mount(
+      <NavItem href="http://www.digitalriver.com" navKey={0}>
+        HOME
+      </NavItem>
+    );
+    expect(navItem.find("a").exists()).toBe(true);
+    expect(navItem.find("a").props().href).toBe("http://www.digitalriver.com");
+  });
+
+  it("If as prop contains value, render Link element", function() {
+    const navItem = mount(
+      <HashRouter hashType="noslash">
+        <Nav activeIndex={0}>
+          <Nav>
+            <NavItem navKey={0} as={NavLink} to="button">
+              HOME
+            </NavItem>
+          </Nav>
+        </Nav>
+      </HashRouter>
+    );
+    expect(navItem.find("a").exists()).toBe(true);
+    expect(navItem.find("Link").exists()).toBe(true);
+  });
+
+  it("If prop to exists, Button href and onClick should be null", function() {
+    const navItem = mount(
+      <HashRouter hashType="noslash">
+        <Nav activeIndex={0}>
+          <Nav>
+            <NavItem navKey={0} as={NavLink} to="button">
+              HOME
+            </NavItem>
+          </Nav>
+        </Nav>
+      </HashRouter>
+    );
+    expect(navItem.find("Button").props().href).toBe(null);
+    expect(navItem.find("Button").props().onClick).toBe(null);
+  });
+
+  it("Should pass style", function() {
+    const navItem = mount(
+      <NavItem style={{ "color": "red" }} navKey={0}>
+        HOME
+      </NavItem>
+    );
+    expect(navItem.props().style).toEqual({ "color": "red" });
+    expect(navItem.html()).toContain('style="color: red;"');
+  });
+
+  it("Should not have onClick if onClick is not in props", function() {
+    const navItem = mount(<NavItem navKey={0}>HOME</NavItem>);
+    expect(typeof navItem.props().onClick).toBe("undefined");
+  });
+});


### PR DESCRIPTION
- "to" wasn't defined, so not sure how that was even working before.  updated code in NavItem to use this.props.to instead, and added to to propTypes (I tried adding it up in the props list but that caused other issues, conflicts with react-router-dom I think caused errors on docs)
- added snapshot test
- added test file - this didn't add a lot of coverage, but it did add some.  I think a lot was getting covered in Nav but I felt like it needed its own test file.  There is one branch that I couldn't figure out, but everything else should have complete coverage now.