### PR TITLE
Portal tests

### DIFF
--- a/src/Portal/__tests__/__snapshots__/portal.test.js.snap
+++ b/src/Portal/__tests__/__snapshots__/portal.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test correct render Test correct render 1`] = `null`;

--- a/src/Portal/__tests__/portal.test.js
+++ b/src/Portal/__tests__/portal.test.js
@@ -1,0 +1,61 @@
+import React from "react";
+import { mount } from "enzyme";
+import { Portal } from "../index";
+
+import renderer from "react-test-renderer";
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("Test correct render", () => {
+  it("Test correct render", function() {
+    const tree = renderer.create(<Portal />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});
+
+describe("Testing Portal component", () => {
+  it("applies props correctly", function() {
+    mount(
+      <Portal className="myClass">
+        <div>foo</div>
+      </Portal>
+    );
+    expect(document.body.querySelector(".ra_Portal__portal").className).toBe(
+      "ra_Portal__portal myClass"
+    );
+  });
+
+  it("applies default props correctly", function() {
+    mount(
+      <Portal>
+        <div>foo</div>
+      </Portal>
+    );
+    expect(document.body.querySelector(".ra_Portal__portal").className).toBe(
+      "ra_Portal__portal"
+    );
+  });
+
+  it("unmount removes element", function() {
+    const portal = mount(
+      <Portal>
+        <div>foo</div>
+      </Portal>
+    );
+    portal.unmount();
+    expect(document.body.innerHTML).toBe("");
+  });
+
+  it("rerenders appropriately with new props", function() {
+    let className = "myClass";
+    const portal = mount(
+      <Portal className={className}>
+        <div>foo</div>
+      </Portal>
+    );
+    portal.setProps({ className: "myNewClass" });
+    expect(document.body.querySelectorAll(".myNewClass").length).toBe(1);
+  });
+});

--- a/src/ProgressBar/ProgressBar.js
+++ b/src/ProgressBar/ProgressBar.js
@@ -161,13 +161,6 @@ ProgressBar.propTypes = {
   mode: PropTypes.string,
 
   /**
-   * If true, ProgressBar will change colors during transition
-   *
-   * @ignore
-   */
-  multicolor: PropTypes.bool,
-
-  /**
    * Pass inline styling here.
    */
   style: PropTypes.object,
@@ -203,7 +196,6 @@ ProgressBar.defaultProps = {
   min: 0,
   transitionDuration: ".35s",
   mode: "indeterminate",
-  multicolor: false,
   type: "linear",
   value: 0
 };

--- a/src/ProgressBar/__tests__/__snapshots__/progressBar.test.js.snap
+++ b/src/ProgressBar/__tests__/__snapshots__/progressBar.test.js.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test correct render Test correct render circular 1`] = `
+<div
+  aria-valuemax={100}
+  aria-valuemin={0}
+  aria-valuenow={0}
+  className="circular indeterminate"
+  style={undefined}
+>
+  <svg
+    className="circle"
+    viewBox="0 0 60 60"
+  >
+    <circle
+      className="path"
+      cx="30"
+      cy="30"
+      r="25"
+      style={
+        Object {
+          "stroke": undefined,
+        }
+      }
+    />
+  </svg>
+</div>
+`;
+
+exports[`Test correct render Test correct render default linear 1`] = `
+<div
+  aria-valuemax={100}
+  aria-valuemin={0}
+  aria-valuenow={0}
+  className="linear indeterminate"
+  style={undefined}
+>
+  <div>
+    <span
+      className="buffer"
+      data-ref="buffer"
+      style={undefined}
+    />
+    <span
+      className="value"
+      data-ref="value"
+      style={
+        Object {
+          "backgroundColor": undefined,
+        }
+      }
+    />
+  </div>
+</div>
+`;

--- a/src/ProgressBar/__tests__/progressBar.test.js
+++ b/src/ProgressBar/__tests__/progressBar.test.js
@@ -1,0 +1,202 @@
+import React from "react";
+import { mount } from "enzyme";
+import { ProgressBar } from "../index";
+
+import renderer from "react-test-renderer";
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("Test correct render", () => {
+  it("Test correct render default linear", function() {
+    const tree = renderer.create(<ProgressBar />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("Test correct render circular", function() {
+    const tree = renderer.create(<ProgressBar type="circular" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});
+
+describe("Testing Portal component", () => {
+  it("applies default props correctly", function() {
+    const pb = mount(<ProgressBar />);
+    expect(pb.props().buffer).toBe(0);
+    expect(pb.props().className).toBe("");
+    expect(pb.props().max).toBe(100);
+    expect(pb.props().min).toBe(0);
+    expect(pb.props().transitionDuration).toBe(".35s");
+    expect(pb.props().mode).toBe("indeterminate");
+    expect(pb.props().type).toBe("linear");
+    expect(pb.props().value).toBe(0);
+  });
+
+  it("linear type renders two spans", function() {
+    const pb = mount(<ProgressBar type="linear" />);
+    expect(pb.find("span").length).toBe(2);
+    expect(
+      pb
+        .find("span")
+        .first()
+        .props().className
+    ).toBe("buffer");
+    expect(
+      pb
+        .find("span")
+        .last()
+        .props().className
+    ).toBe("value");
+  });
+
+  it("determinate linear type renders with style transform", function() {
+    const pb = mount(<ProgressBar type="linear" mode="determinate" />);
+    expect(pb.find("span").length).toBe(2);
+    expect(
+      pb
+        .find("span")
+        .first()
+        .props().className
+    ).toBe("buffer");
+    expect(
+      pb
+        .find("span")
+        .first()
+        .props().style.transform
+    ).toBeDefined();
+    expect(
+      pb
+        .find("span")
+        .last()
+        .props().className
+    ).toBe("value");
+    expect(
+      pb
+        .find("span")
+        .last()
+        .props().style.transform
+    ).toBeDefined();
+  });
+
+  it("calculates ratio correctly for min", function() {
+    const pb = mount(
+      <ProgressBar
+        type="linear"
+        mode="determinate"
+        min={0}
+        max={100}
+        value={-1}
+      />
+    );
+    expect(pb.find("span").length).toBe(2);
+    expect(
+      pb
+        .find("span")
+        .first()
+        .props().className
+    ).toBe("buffer");
+    expect(
+      pb
+        .find("span")
+        .first()
+        .props().style.transform
+    ).toContain("scaleX(0)");
+  });
+
+  it("calculates ratio correctly for max", function() {
+    const pb = mount(
+      <ProgressBar
+        type="linear"
+        mode="determinate"
+        min={0}
+        max={50}
+        value={100}
+      />
+    );
+    expect(pb.find("span").length).toBe(2);
+    expect(
+      pb
+        .find("span")
+        .last()
+        .props().className
+    ).toBe("value");
+    expect(
+      pb
+        .find("span")
+        .last()
+        .props().style.transform
+    ).toContain("scaleX(1)");
+  });
+
+  it("renders range when value is not a number", function() {
+    const pb = mount(
+      <ProgressBar type="linear" value={{ from: 10, to: 50 }} />
+    );
+    expect(pb.find("span").length).toBe(1);
+    expect(
+      pb
+        .find("span")
+        .last()
+        .props().className
+    ).toBe("value");
+    expect(
+      pb
+        .find("span")
+        .last()
+        .props().style.transform
+    ).toContain("translateX(10%)");
+    expect(
+      pb
+        .find("span")
+        .last()
+        .props().style.transform
+    ).toContain("scaleX(0.4)");
+  });
+
+  it("circular type renders an svg", function() {
+    const pb = mount(<ProgressBar type="circular" />);
+    expect(pb.find("svg").length).toBe(1);
+    expect(pb.find("svg").props().className).toBe("circle");
+    expect(pb.find("circle").props().className).toBe("path");
+  });
+
+  it("determinate type renders style strokeDasharray", function() {
+    const pb = mount(<ProgressBar type="circular" mode="determinate" />);
+    expect(pb.find("svg").length).toBe(1);
+    expect(pb.find("svg").props().className).toBe("circle");
+    expect(pb.find("circle").props().className).toBe("path");
+    expect(pb.find("circle").props().style.strokeDasharray).toBeDefined();
+  });
+
+  it("handles color and style props", function() {
+    const pb = mount(
+      <ProgressBar
+        type="circular"
+        color="blue"
+        style={{ backgroundColor: "red" }}
+      />
+    );
+    console.log(pb.html());
+    expect(pb.find("circle").props().style.stroke).toEqual("blue");
+    expect(pb.find("div").props().style).toEqual({ backgroundColor: "red" });
+  });
+
+  it("linear determinate handles transitionDuration props", function() {
+    const pb = mount(
+      <ProgressBar type="linear" mode="determinate" transitionDuration=".35s" />
+    );
+    expect(
+      pb
+        .find("span")
+        .first()
+        .props().style.transitionDuration
+    ).toContain(".35s");
+    expect(
+      pb
+        .find("span")
+        .last()
+        .props().style.transitionDuration
+    ).toContain(".35s");
+  });
+});


### PR DESCRIPTION
Portal:
- added tests directory with snapshot test and test file
- coverage for Portal will be at 100% after this PR is merged
- note:  noticed that it doesn't appear that the style prop is used anywhere, but did not remove it from propTypes.  If you think I should do that, let me know.

ProgressBar:
- removed propType definition and default for multiColor, since code does nothing with it and it makes me sad everytime I see it and know I can't have a rainbow progress bar
- added tests directory, snapshot test and test file
- coverage for ProgressBar will be at 100% after this PR is merged